### PR TITLE
Tweak to see if we can get the new colour picking code working

### DIFF
--- a/source/shared_lib/include/graphics/model.h
+++ b/source/shared_lib/include/graphics/model.h
@@ -278,8 +278,8 @@ public:
 private:
 	unsigned char uniqueColorID[COLOR_COMPONENTS];
 
-    static int nextColorID;
-    static const int k, p;
+    static unsigned nextColorID;
+    static const unsigned k, p;
     static Mutex mutexNextColorID;
 
     static auto_ptr<PixelBufferWrapper> pbo;

--- a/source/shared_lib/sources/graphics/model.cpp
+++ b/source/shared_lib/sources/graphics/model.cpp
@@ -1826,9 +1826,9 @@ PixelBufferWrapper::~PixelBufferWrapper() {
 	cleanup();
 }
 
-const int BaseColorPickEntity::p = 64007;
-const int BaseColorPickEntity::k = 43067;
-int BaseColorPickEntity::nextColorID = BaseColorPickEntity::k;
+const unsigned BaseColorPickEntity::p = 64007;
+const unsigned BaseColorPickEntity::k = 43067;
+unsigned BaseColorPickEntity::nextColorID = BaseColorPickEntity::k;
 Mutex BaseColorPickEntity::mutexNextColorID;
 auto_ptr<PixelBufferWrapper> BaseColorPickEntity::pbo;
 
@@ -1845,7 +1845,7 @@ void BaseColorPickEntity::assign_color() {
 	 // nextColorID is a 16-bit (hi)colour (for players with 16-bit display depths)
 	 // we expand it to true-color for use with OpenGL
 	 
-	 const int
+	 const unsigned
 	 	r = (nextColorID >> 11) & ((1<<5)-1),
 	 	g = (nextColorID >> 5) & ((1<<6)-1),
 	 	b = nextColorID & ((1<<5)-1);


### PR DESCRIPTION
I think the bug in the old code is in it calling reuse or reset colours too often.

I also wanted to pick distinctive colours to make any debugging of colour picking easier.

Here's an example pbo now:
![toll](https://f.cloud.github.com/assets/223723/1649661/c08a2f5a-5a19-11e3-922f-119ab7336de8.png)
