### PR TITLE
lua libs and headers found in right order / arch dynamic libs

### DIFF
--- a/build-mg.sh
+++ b/build-mg.sh
@@ -140,6 +140,10 @@ case $distribution in
 				;;
 		esac
 		;;
+	Arch)
+	echo 'Turning ON dynamic LIBS ...'
+	EXTRA_CMAKE_OPTIONS="${EXTRA_CMAKE_OPTIONS} -DWANT_STATIC_LIBS=OFF"
+	;;
 esac
 
 #exit 1;

--- a/mk/cmake/Modules/FindLUA.cmake
+++ b/mk/cmake/Modules/FindLUA.cmake
@@ -20,8 +20,8 @@ ENDIF(LUA_INCLUDE_DIR AND LUA_LIBRARIES)
 
 FIND_PATH(LUA_INCLUDE_DIR NAMES lua.hpp 
 		PATHS 	/usr/include
-			/usr/include/lua
                         /usr/include/lua5.2
+			/usr/include/lua
 			/usr/include/lua5.1
 		IF(FreeBSD)
                 	SET(PATHS "/usr/local/include/lua51")
@@ -30,7 +30,7 @@ FIND_PATH(LUA_INCLUDE_DIR NAMES lua.hpp
 		)
 
 IF (LUA_STATIC AND NOT LUA_LIBRARIES)
-	FIND_LIBRARY(LUA_LIBRARIES NAMES liblua5.2.a liblua.a liblua5.1.a lua5.1 lua
+	FIND_LIBRARY(LUA_LIBRARIES NAMES liblua5.2.a liblua.a liblua5.1.a lua5.2 lua lua5.1
 		PATHS 
                 IF(FreeBSD)
                        SET(PATHS "/usr/local/lib/lua51")


### PR DESCRIPTION
lua libs and headers are looking for the lua versions in the same order
static libs disabled for arch
