### PR TITLE
Implemented HP and EP starting values

### DIFF
--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -1951,7 +1951,17 @@ void Unit::born(const CommandType *ct) {
 
 	checkItemInVault(&this->hp,this->hp);
 	int original_hp = this->hp;
-	this->hp= type->getMaxHp();
+
+	
+	//set hp from start hp
+	checkItemInVault(&this->ep,this->ep);
+	if(type->getStartHpType() == UnitType::stValue) {
+		this->hp= type->getStartHpValue();
+	}
+	else {
+		this->hp= type->getStartHpPercentage() * type->getTotalMaxHp(&totalUpgrade);
+	}
+
 	if(original_hp != this->hp) {
 		//printf("File: %s line: %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__LINE__);
 		game->getScriptManager()->onUnitTriggerEvent(this,utet_HPChanged);

--- a/source/glest_game/types/unit_type.cpp
+++ b/source/glest_game/types/unit_type.cpp
@@ -125,6 +125,9 @@ UnitType::UnitType() : ProducibleType() {
 	epRegeneration= 0;
 	maxUnitCount= 0;
 	maxHp=0;
+	startHpValue=0;
+	startHpPercentage=1.0;
+	startHpType=stValue;
 	maxEp=0;
 	startEpValue=0;
 	startEpPercentage=0;
@@ -249,6 +252,36 @@ void UnitType::loaddd(int id,const string &dir, const TechTree *techTree,
 			epRegeneration= parametersNode->getChild("max-ep")->getAttribute("regeneration")->getIntValue();
 		}
 		addItemToVault(&(this->epRegeneration),this->epRegeneration);
+
+		// Check that we don't use both start-value and start-percentage, as they are mutually
+		// exclusive
+		if(parametersNode->getChild("max-hp")->hasAttribute("start-value") &&
+				parametersNode->getChild("max-hp")->hasAttribute("start-percentage")) {
+					throw megaglest_runtime_error("Unit " + name +
+							" has both start-value and start-percentage for HP", validationMode);
+		}
+
+		//startHpValue -- the *absolute* value to use for starting HP
+		if(parametersNode->getChild("max-hp")->hasAttribute("start-value")) {
+			//checkItemInVault(&(this->startEp),this->startEp);
+			startHpValue= parametersNode->getChild("max-hp")->getAttribute("start-value")->getIntValue();
+			startHpType= stValue;
+		}
+		addItemToVault(&(this->startHpValue),this->startHpValue);
+
+		//startHpPercentage -- the *relative* value to use for starting HP
+		if(parametersNode->getChild("max-hp")->hasAttribute("start-percentage")) {
+			startHpPercentage= parametersNode->getChild("max-hp")->getAttribute("start-percentage")->getFloatValue();
+			startHpType= stPercentage;
+		}
+
+		// No start value set; use max HP before upgrades
+		if(!parametersNode->getChild("max-hp")->hasAttribute("start-value") &&
+				!parametersNode->getChild("max-hp")->hasAttribute("start-percentage")) {
+			startHpValue= parametersNode->getChild("max-hp")->getAttribute("value")->getIntValue();
+			startHpType= stValue;
+		}
+		addItemToVault(&(this->startHpPercentage),this->startHpPercentage);
 
 		// Check that we don't use both start-value and start-percentage, as they are mutually
 		// exclusive

--- a/source/glest_game/types/unit_type.h
+++ b/source/glest_game/types/unit_type.h
@@ -109,6 +109,9 @@ private:
 	//basic
 	int id;
 	int maxHp;
+    int startHpValue;
+    double startHpPercentage;
+	StartType startHpType;
 	int hpRegeneration;
     int maxEp;
     int startEpValue;
@@ -186,6 +189,9 @@ public:
     inline int getId() const									{return id;}
     inline int getMaxHp() const								{return maxHp;}
     inline int getHpRegeneration() const						{return hpRegeneration;}
+    inline int getStartHpValue() const						{return startHpValue;}
+    inline double getStartHpPercentage() const						{return startHpPercentage;}
+    inline StartType getStartHpType() const						{return startHpType;}
     inline int getMaxEp() const								{return maxEp;}
     inline int getEpRegeneration() const						{return epRegeneration;}
     inline int getStartEpValue() const						{return startEpValue;}


### PR DESCRIPTION
The absolute or percentage starting value can now be set for either HP or EP.

Setting the absolute value is done with `start-value`, while setting the percentage is done with `start-percentage`. Both of these are attributes of the `max-hp` and `max-ep` tags (different from Tiger's changes, which had the starting EP a tag of its own).

The starting percentages are always a percentage of the upgraded max value. Thus, if a unit normally has 1000 max HP and an upgrade is in effect that increases its HP by 500, then setting the max hp to have a starting percentage of 0.5 will result in the unit starting with 750 HP (the result of (1000 + 500) \* 0.5).

This is particularly useful because the default behavior is to have units start with their max HP, even if they have upgrades that boost HP. Thus, if you want your units to be created with a starting HP equal to their true max HP (with upgrades), set the percentage starting value to 1.0.

Note that `start-value` and `start-percentage` are mutually exclusive. You cannot use both at the same time. Attempting to do so will cause a runtime error.

I have tested various combinations of starting values and percentages with and without upgrades.

Example:

``` xml
<!-- ... -->
<max-hp value="500" start-percentage="1.0" />
<max-ep value="1000" regeneration="5" start-value="500" />
<!-- ... -->
```
## Known issues
- Setting the starting HP to 0 causes the unit to be immortal. This actually may be a feature.
