### PR TITLE
Fix for the animationbound-particles

### DIFF
--- a/source/glest_game/types/skill_type.cpp
+++ b/source/glest_game/types/skill_type.cpp
@@ -504,11 +504,18 @@ void SkillType::load(const XmlNode *sn, const XmlNode *attackBoostsNode,
 				unitParticleSystemType->load(particleFileNode, dir, currentPath + path, &Renderer::getInstance(),
 						loadedFileList,parentLoader,tt->getPath());
 
-				if(particleNode->getAttribute("start-time",false) != NULL) {
+				if (particleNode->getChild(i)->hasAttribute("start-time")) {
+					//printf("*NOTE particle system type has start-time [%f]\n",particleNode->getAttribute("start-time")->getFloatValue());
+					unitParticleSystemType->setStartTime(particleNode->getChild(i)->getAttribute("start-time")->getFloatValue());
+				} else if (particleNode->hasAttribute("start-time")) {
 					//printf("*NOTE particle system type has start-time [%f]\n",particleNode->getAttribute("start-time")->getFloatValue());
 					unitParticleSystemType->setStartTime(particleNode->getAttribute("start-time")->getFloatValue());
 				}
-				if(particleNode->getAttribute("end-time",false) != NULL) {
+
+				if (particleNode->getChild(i)->hasAttribute("end-time")) {
+					//printf("*NOTE particle system type has start-time [%f]\n",particleNode->getAttribute("start-time")->getFloatValue());
+					unitParticleSystemType->setEndTime(particleNode->getChild(i)->getAttribute("end-time")->getFloatValue());
+				} else if (particleNode->hasAttribute("end-time")) {
 					//printf("*NOTE particle system type has end-time [%f]\n",particleNode->getAttribute("end-time")->getFloatValue());
 					unitParticleSystemType->setEndTime(particleNode->getAttribute("end-time")->getFloatValue());
 				}


### PR DESCRIPTION
This is a fix and extension to the current implementation of the animationbound particle start-time and end-time.
In this fix i used `hasAttribute("start-time")` instead of `getAttribute("start-time",false) != NULL` , because i think this is more correct and expand the functionality to individual start/end-times for every particle system.

So the syntax is:

```
            <particles value="true" start-time="0.8" end-time="1">
                <particle-file path="particles1.xml" start-time="0.28" end-time="0.5"/>
                <particle-file path="particles1.xml"/>
            </particles>
```

If no start/end-time is given in `<particle-file>` the start-time from the `<particles>` node will be used ( to be backwards compatible )

I am not 100% sure if this is correct because you define the start-time in a xml-node called `<particle-file>` now, but the previous implementation was not that useful to me.
