### PR TITLE
non commandable units

### DIFF
--- a/source/glest_game/ai/ai.cpp
+++ b/source/glest_game/ai/ai.cpp
@@ -531,7 +531,7 @@ bool Ai::findAbleUnit(int *unitIndex, CommandClass ability, bool idleOnly){
 	*unitIndex= -1;
 	for(int i=0; i<aiInterface->getMyUnitCount(); ++i){
 		const Unit *unit= aiInterface->getMyUnit(i);
-		if(unit->getType()->hasCommandClass(ability)){
+		if(unit->getType()->isCommandable() && unit->getType()->hasCommandClass(ability)){
 			if(!idleOnly || !unit->anyCommand() || unit->getCurrCommand()->getCommandType()->getClass()==ccStop){
 				units.push_back(i);
 			}
@@ -553,55 +553,57 @@ vector<int> Ai::findUnitsHarvestingResourceType(const ResourceType *rt) {
 	Map *map= aiInterface->getMap();
 	for(int i = 0; i < aiInterface->getMyUnitCount(); ++i) {
 		const Unit *unit= aiInterface->getMyUnit(i);
-		if(unit->getType()->hasCommandClass(ccHarvest)) {
-			if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccHarvest) {
-				Command *command= unit->getCurrCommand();
-			    const HarvestCommandType *hct= dynamic_cast<const HarvestCommandType*>(command->getCommandType());
-			    if(hct != NULL) {
-					const Vec2i unitTargetPos = unit->getTargetPos();
-					SurfaceCell *sc= map->getSurfaceCell(Map::toSurfCoords(unitTargetPos));
-					Resource *r= sc->getResource();
-					if (r != NULL && r->getType() == rt) {
-						units.push_back(i);
-					}
-			    }
-			}
-		}
-		else if(unit->getType()->hasCommandClass(ccProduce)) {
-			if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccProduce) {
-				Command *command= unit->getCurrCommand();
-			    const ProduceCommandType *pct= dynamic_cast<const ProduceCommandType*>(command->getCommandType());
-			    if(pct != NULL) {
-			    	const UnitType *ut = pct->getProducedUnit();
-			    	if(ut != NULL) {
-						const Resource *r = ut->getCost(rt);
-						if(r != NULL) {
-							if (r != NULL && r->getAmount() < 0) {
-								units.push_back(i);
-							}
+		if(unit->getType()->isCommandable()) {
+			if(unit->getType()->hasCommandClass(ccHarvest)) {
+				if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccHarvest) {
+					Command *command= unit->getCurrCommand();
+					const HarvestCommandType *hct= dynamic_cast<const HarvestCommandType*>(command->getCommandType());
+					if(hct != NULL) {
+						const Vec2i unitTargetPos = unit->getTargetPos();
+						SurfaceCell *sc= map->getSurfaceCell(Map::toSurfCoords(unitTargetPos));
+						Resource *r= sc->getResource();
+						if (r != NULL && r->getType() == rt) {
+							units.push_back(i);
 						}
-			    	}
-			    }
+					}
+				}
 			}
-		}
-		else if(unit->getType()->hasCommandClass(ccBuild)) {
-			if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccBuild) {
-				Command *command= unit->getCurrCommand();
-			    const BuildCommandType *bct= dynamic_cast<const BuildCommandType*>(command->getCommandType());
-			    if(bct != NULL) {
-			    	for(int j = 0; j < bct->getBuildingCount(); ++j) {
-						const UnitType *ut = bct->getBuilding(j);
+			else if(unit->getType()->hasCommandClass(ccProduce)) {
+				if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccProduce) {
+					Command *command= unit->getCurrCommand();
+					const ProduceCommandType *pct= dynamic_cast<const ProduceCommandType*>(command->getCommandType());
+					if(pct != NULL) {
+						const UnitType *ut = pct->getProducedUnit();
 						if(ut != NULL) {
 							const Resource *r = ut->getCost(rt);
 							if(r != NULL) {
 								if (r != NULL && r->getAmount() < 0) {
 									units.push_back(i);
-									break;
 								}
 							}
 						}
-			    	}
-			    }
+					}
+				}
+			}
+			else if(unit->getType()->hasCommandClass(ccBuild)) {
+				if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == ccBuild) {
+					Command *command= unit->getCurrCommand();
+					const BuildCommandType *bct= dynamic_cast<const BuildCommandType*>(command->getCommandType());
+					if(bct != NULL) {
+						for(int j = 0; j < bct->getBuildingCount(); ++j) {
+							const UnitType *ut = bct->getBuilding(j);
+							if(ut != NULL) {
+								const Resource *r = ut->getCost(rt);
+								if(r != NULL) {
+									if (r != NULL && r->getAmount() < 0) {
+										units.push_back(i);
+										break;
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 	}
@@ -614,7 +616,7 @@ vector<int> Ai::findUnitsDoingCommand(CommandClass currentCommand) {
 
 	for(int i = 0; i < aiInterface->getMyUnitCount(); ++i) {
 		const Unit *unit= aiInterface->getMyUnit(i);
-		if(unit->getType()->hasCommandClass(currentCommand)) {
+		if(unit->getType()->isCommandable() && unit->getType()->hasCommandClass(currentCommand)) {
 			if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass() == currentCommand) {
 				units.push_back(i);
 			}
@@ -630,7 +632,7 @@ bool Ai::findAbleUnit(int *unitIndex, CommandClass ability, CommandClass current
 	*unitIndex= -1;
 	for(int i=0; i<aiInterface->getMyUnitCount(); ++i){
 		const Unit *unit= aiInterface->getMyUnit(i);
-		if(unit->getType()->hasCommandClass(ability)){
+		if(unit->getType()->isCommandable() && unit->getType()->hasCommandClass(ability)){
 			if(unit->anyCommand() && unit->getCurrCommand()->getCommandType()->getClass()==currentCommand){
 				units.push_back(i);
 			}

--- a/source/glest_game/gui/selection.cpp
+++ b/source/glest_game/gui/selection.cpp
@@ -71,12 +71,7 @@ bool Selection::select(Unit *unit) {
 			return false;
 		}
 
-		//check if selectable
-		if(unit->getType()->isSelectable() == false) {
-			return false;
-		}
-
-		//check if selectable
+		//check if commandable
 		if(unit->getType()->isCommandable() == false && isEmpty() == false) {
 			return false;
 		}

--- a/source/glest_game/types/unit_type.cpp
+++ b/source/glest_game/types/unit_type.cpp
@@ -89,7 +89,6 @@ UnitType::UnitType() : ProducibleType() {
     lightColor= Vec3f(0.f);
     light= false;
     multiSelect= false;
-    selectable= true;
     commandable= true;
 	armorType= NULL;
 	rotatedBuildPos=0;
@@ -335,10 +334,6 @@ void UnitType::loaddd(int id,const string &dir, const TechTree *techTree,
 		//multi selection
 		multiSelect= parametersNode->getChild("multi-selection")->getAttribute("value")->getBoolValue();
 
-		//selectable
-		if(parametersNode->hasChild("selectable")){
-			selectable= parametersNode->getChild("selectable")->getAttribute("value")->getBoolValue();
-		}
 		//commandable
 		if(parametersNode->hasChild("commandable")){
 			commandable= parametersNode->getChild("commandable")->getAttribute("value")->getBoolValue();
@@ -1250,7 +1245,6 @@ std::string UnitType::toString() const {
 	result += " light = " + intToStr(light);
 	result += " lightColor = " + lightColor.getString();
 	result += " multiSelect = " + intToStr(multiSelect);
-	result += " selectable = " + intToStr(selectable);
 	result += " commandable = " + intToStr(commandable);
 	result += " sight = " + intToStr(sight);
 	result += " size = " + intToStr(size);

--- a/source/glest_game/types/unit_type.h
+++ b/source/glest_game/types/unit_type.h
@@ -171,7 +171,6 @@ private:
 	bool light;
     Vec3f lightColor;
     bool multiSelect;
-    bool selectable;
     bool commandable;
     int sight;
     int size;							//size in cells
@@ -257,7 +256,6 @@ public:
 	inline bool getRotationAllowed() const						{return rotationAllowed;}
 	inline Vec3f getLightColor() const							{return lightColor;}
 	inline bool getMultiSelect() const							{return multiSelect;}
-	inline bool isSelectable() const							{return selectable;}
 	inline bool isCommandable() const							{return commandable;}
 	inline int getSight() const								{return sight;}
 	inline int getSize() const									{return size;}


### PR DESCRIPTION
Added a boolean to units.

 **commandable  |** if this is false, you cant give the units commands.

This is mainly made for the spawn attack, because you may want for example spawn bees in a beehive which you are not able to select or control. I also recommend to accept my other pull request about the spawn attack together with this one.

New Syntax:

``` xml
<unit>
    <parameters>
                ...
        <time value="25"/>  
        <multi-selection value="true"/>
        <commandable value="false"/>        
        <cellmap value="false"/>
        <levels/>
                ...
    </parameters>
...
</unit>
```
