### PR TITLE
Feature/shared team options in scenarios

### DIFF
--- a/source/glest_game/menu/menu_state_connected_game.cpp
+++ b/source/glest_game/menu/menu_state_connected_game.cpp
@@ -4565,6 +4565,9 @@ void MenuStateConnectedGame::setupUIFromGameSettings(GameSettings *gameSettings,
 			listBoxFogOfWar.setSelectedItemIndex(0);
 		}
 
+		checkBoxAllowTeamUnitSharing.setValue(scenarioInfo.allowTeamUnitSharing);
+		checkBoxAllowTeamResourceSharing.setValue(scenarioInfo.allowTeamResourceSharing);
+
 		if(originalFOWValue != listBoxFogOfWar.getSelectedItemIndex()) {
 			cleanupMapPreviewTexture();
 		}

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4888,8 +4888,8 @@ void MenuStateCustomGame::SetupUIForScenarios() {
 			}
 			listBoxFogOfWar.setEditable(true);
 			checkBoxAllowObservers.setEditable(true);
-			checkBoxAllowTeamUnitSharing.setEditable(false);
-			checkBoxAllowTeamResourceSharing.setEditable(false);
+			checkBoxAllowTeamUnitSharing.setEditable(true);
+			checkBoxAllowTeamResourceSharing.setEditable(true);
 			//listBoxPathFinderType.setEditable(true);
 			checkBoxEnableSwitchTeamMode.setEditable(true);
 			listBoxAISwitchTeamAcceptPercent.setEditable(true);

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -3994,6 +3994,8 @@ void MenuStateCustomGame::setupUIFromGameSettings(const GameSettings &gameSettin
 		else {
 			listBoxFogOfWar.setSelectedItemIndex(0);
 		}
+		checkBoxAllowTeamUnitSharing.setValue(scenarioInfo.allowTeamUnitSharing);
+		checkBoxAllowTeamResourceSharing.setValue(scenarioInfo.allowTeamResourceSharing);
 	}
 	setupMapList(gameSettings.getScenario());
 	setupTechList(gameSettings.getScenario(),false);
@@ -4690,6 +4692,9 @@ void MenuStateCustomGame::processScenario() {
 			else {
 				listBoxFogOfWar.setSelectedItemIndex(0);
 			}
+
+			checkBoxAllowTeamUnitSharing.setValue(scenarioInfo.allowTeamUnitSharing);
+			checkBoxAllowTeamResourceSharing.setValue(scenarioInfo.allowTeamResourceSharing);
 
 			setupTechList(scenarioInfo.name, false);
 			listBoxTechTree.setSelectedItem(formatString(scenarioInfo.techTreeName));

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4866,6 +4866,8 @@ void MenuStateCustomGame::SetupUIForScenarios() {
 			}
 			listBoxFogOfWar.setEditable(false);
 			checkBoxAllowObservers.setEditable(false);
+			checkBoxAllowTeamUnitSharing.setEditable(false);
+			checkBoxAllowTeamResourceSharing.setEditable(false);
 			//listBoxPathFinderType.setEditable(false);
 			checkBoxEnableSwitchTeamMode.setEditable(false);
 			listBoxAISwitchTeamAcceptPercent.setEditable(false);
@@ -4886,6 +4888,8 @@ void MenuStateCustomGame::SetupUIForScenarios() {
 			}
 			listBoxFogOfWar.setEditable(true);
 			checkBoxAllowObservers.setEditable(true);
+			checkBoxAllowTeamUnitSharing.setEditable(false);
+			checkBoxAllowTeamResourceSharing.setEditable(false);
 			//listBoxPathFinderType.setEditable(true);
 			checkBoxEnableSwitchTeamMode.setEditable(true);
 			listBoxAISwitchTeamAcceptPercent.setEditable(true);

--- a/source/glest_game/world/scenario.cpp
+++ b/source/glest_game/world/scenario.cpp
@@ -394,7 +394,7 @@ void Scenario::loadScenarioInfo(string file, ScenarioInfo *scenarioInfo, bool is
 
 	if(scenarioNode->hasChild("shared-team-units") == true) {
 		scenarioInfo->allowTeamUnitSharing=scenarioNode->getChild("shared-team-units")->getAttribute("value")->getBoolValue();
-		//printf("\nallowTeamUnitSharing is set to [%B]\n",scenarioInfo->allowTeamUnitSharing);
+		//printf("\nallowTeamUnitSharing is set to [%s]\n",scenarioInfo->allowTeamUnitSharing);
 	}
 	else {
 		scenarioInfo->allowTeamUnitSharing = false;
@@ -402,7 +402,7 @@ void Scenario::loadScenarioInfo(string file, ScenarioInfo *scenarioInfo, bool is
 
 	if(scenarioNode->hasChild("shared-team-resources") == true) {
 		scenarioInfo->allowTeamResourceSharing=scenarioNode->getChild("shared-team-resources")->getAttribute("value")->getBoolValue();
-		//printf("\nallowTeamResourceSharing is set to [%B]\n",scenarioInfo->allowTeamResourceSharing);
+		//printf("\nallowTeamResourceSharing is set to [%s]\n",scenarioInfo->allowTeamResourceSharing);
 	}
 	else {
 		scenarioInfo->allowTeamResourceSharing = false;

--- a/source/glest_game/world/scenario.cpp
+++ b/source/glest_game/world/scenario.cpp
@@ -392,6 +392,22 @@ void Scenario::loadScenarioInfo(string file, ScenarioInfo *scenarioInfo, bool is
 		scenarioInfo->fogOfWar_exploredFlag = false;
 	}
 
+	if(scenarioNode->hasChild("shared-team-units") == true) {
+		scenarioInfo->allowTeamUnitSharing=scenarioNode->getChild("shared-team-units")->getAttribute("value")->getBoolValue();
+		//printf("\nallowTeamUnitSharing is set to [%B]\n",scenarioInfo->allowTeamUnitSharing);
+	}
+	else {
+		scenarioInfo->allowTeamUnitSharing = false;
+	}
+
+	if(scenarioNode->hasChild("shared-team-resources") == true) {
+		scenarioInfo->allowTeamResourceSharing=scenarioNode->getChild("shared-team-resources")->getAttribute("value")->getBoolValue();
+		//printf("\nallowTeamResourceSharing is set to [%B]\n",scenarioInfo->allowTeamResourceSharing);
+	}
+	else {
+		scenarioInfo->allowTeamResourceSharing = false;
+	}
+
 	scenarioInfo->file = file;
 	scenarioInfo->name = extractFileFromDirectoryPath(file);
 	scenarioInfo->name = cutLastExt(scenarioInfo->name);
@@ -538,6 +554,24 @@ void Scenario::loadGameSettings(const vector<string> &dirList,
 	}
 	else {
         valueFlags1 &= ~ft1_show_map_resources;
+        gameSettings->setFlagTypes1(valueFlags1);
+	}
+
+	if(scenarioInfo->allowTeamUnitSharing == true) {
+        valueFlags1 |= ft1_allow_shared_team_units;
+        gameSettings->setFlagTypes1(valueFlags1);
+	}
+	else {
+        valueFlags1 &= ~ft1_allow_shared_team_units;
+        gameSettings->setFlagTypes1(valueFlags1);
+	}
+
+	if(scenarioInfo->allowTeamResourceSharing == true) {
+        valueFlags1 |= ft1_allow_shared_team_resources;
+        gameSettings->setFlagTypes1(valueFlags1);
+	}
+	else {
+        valueFlags1 &= ~ft1_allow_shared_team_resources;
         gameSettings->setFlagTypes1(valueFlags1);
 	}
 

--- a/source/glest_game/world/scenario.h
+++ b/source/glest_game/world/scenario.h
@@ -68,6 +68,9 @@ public:
 	    fogOfWar = false;
 	    fogOfWar_exploredFlag = false;
 
+	    allowTeamUnitSharing = false;
+	    allowTeamResourceSharing = false;
+
 	    file = "";
 	    name = "";
 	    namei18n = "";
@@ -90,6 +93,9 @@ public:
 
     bool fogOfWar;
     bool fogOfWar_exploredFlag;
+
+    bool allowTeamUnitSharing;
+    bool allowTeamResourceSharing;
 
     string file;
     string name;


### PR DESCRIPTION
 shared team options in scenarios

now you can enable sharedTeamUnits and sharedTeamResources in scenarios

to do so use this two xml tags:
```xml
	<shared-team-units value="false"/>
	<shared-team-resources value="false"/>
```
put them in the```<scenario>``` node