### PR TITLE
Run dos2unix on COPYRIGHT.source_code.txt

### DIFF
--- a/mk/macosx/CMakeLists.txt
+++ b/mk/macosx/CMakeLists.txt
@@ -31,6 +31,9 @@ LINK_DIRECTORIES(/opt/local/lib)
 
 ##install part
 
+# This file is in git CRLF but that causes the cpack run to fail
+EXECUTE_PROCESS(COMMAND dos2unix -k docs/COPYRIGHT.source_code.txt WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
 # This changes Info.plist from something with variables and CMakeisms to
 # something that can be installed on disk.
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/mk/macosx/Info.plist"


### PR DESCRIPTION
COPYRIGHT.source_code.txt is inlined during the package building stage on OSX
when built using Xcode. To prevent it causing Rez to fail due to CRLF line
endings we unconditionally run dos2unix against the file during build. In the
cases where this wouldn't have caused a problem there is no regression and in
the cases where its necesary the file is fixed without manual intervention