### PR TITLE
Changes to make package build and run on osx

### DIFF
--- a/mk/macosx/CMakeLists.txt
+++ b/mk/macosx/CMakeLists.txt
@@ -29,6 +29,9 @@ ENDIF(NOT CONFIG_HAS_BEEN_RUN_BEFORE)
 INCLUDE_DIRECTORIES(/opt/local/include)
 LINK_DIRECTORIES(/opt/local/lib)
 
+# Set custom data path as macos apps don't use /local/
+SET(CUSTOM_DATA_INSTALL_PATH "/Applications/MegaGlest.app/Contents/Resources/share/megaglest/")
+
 ##install part
 
 # This changes Info.plist from something with variables and CMakeisms to
@@ -48,7 +51,20 @@ set (CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/mk/macosx/MegaGlest.icns")
 set (CPACK_RESOURCE_FILE_LICENSE  
      "${CMAKE_CURRENT_SOURCE_DIR}/docs/COPYRIGHT.source_code.txt")
 set (CPACK_BUNDLE_NAME "MegaGlest")
-set (CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/data/glest_game/megaglest")
+
+# This variable changs depending on the build type
+IF(CMAKE_GENERATOR STREQUAL Xcode)
+	IF(CMAKE_BUILD_TYPE STREQUAL Release)
+		set (CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/source/glest_game/Release/megaglest")
+	ELSEIF(CMAKE_BUILD_TYPE STREQUAL Debug)
+		set (CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/source/glest_game/Debug/megaglest")
+	ENDIF()
+ELSE()
+# Assume gnumake
+	set (CPACK_BUNDLE_STARTUP_COMMAND "${PROJECT_SOURCE_DIR}/source/glest_game/megaglest")
+ENDIF()
+
+
 set (CPACK_BUNDLE_ICON  "${CMAKE_CURRENT_SOURCE_DIR}/mk/macosx/MegaGlest.icns")
 set (CPACK_BUNDLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist")
 

--- a/mk/macosx/Info.plist
+++ b/mk/macosx/Info.plist
@@ -5,9 +5,9 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>megaglest</string>
+	<string>MegaGlest</string>
 	<key>CFBundleGetInfoString</key>
-	<string>${VER_MAJOR}.${VER_MINOR}.${VER_RELEASE}, © 2001-2015 The Glest Team All Rights Reserved.</string>
+	<string>${VER_MAJOR}.${VER_MINOR}.${VER_RELEASE}, © 2001-2015 The MegaGlest Team.</string>
 	<key>CFBundleIconFile</key>
 	<string>MegaGlest</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
MegaGlest is the correct spelling, the process of building a package upper
cases the binary so I'm removing my modification via an earlier branch.

This also sets CUSTOM_DATA_INSTALL_PATH to /Applications - this is the final
step in getting MegaGlest.app to launch after building and installing.

The previously hard coded CPACK_BUNDLE_STARTUP_COMMAND path was ok
for gnumake but failed when Xcode got involved as it has build types 
(release/debug/et al) which the hard coding didn't support.
I've added an if/else catch for the two build types that i've
seen while working on megaglest and it should be trivial to add any others that
may be desirable.

There is still an outstanding issue of embedding dependencies or using system
provided dependancies which I haven't sorted out.