### PR TITLE
Specific Tileset with preview-map option

### DIFF
--- a/source/glest_game/main/main.cpp
+++ b/source/glest_game/main/main.cpp
@@ -5044,11 +5044,17 @@ int glestMain(int argc, char** argv) {
 			vector<string> paramPartTokens;
 			Tokenize(mapName,paramPartTokens,"=");
 			if(paramPartTokens.size() >= 2 && paramPartTokens[1].length() > 0) {
-				string autoloadMapName = paramPartTokens[1];
+				vector<string> paramPartTokens2;
+				string tileset="forest";
+				Tokenize(paramPartTokens[1],paramPartTokens2,",");
+				if(paramPartTokens2.size() >= 2 && paramPartTokens2[1].length() > 0) {
+					tileset = paramPartTokens2[1];
+				}
+				string autoloadMapName = paramPartTokens2[0];
 
 				GameSettings *gameSettings = &startupGameSettings;
 				gameSettings->setMap(autoloadMapName);
-				gameSettings->setTileset("forest");
+				gameSettings->setTileset(tileset);
 				gameSettings->setTech("megapack");
 				gameSettings->setDefaultUnits(false);
 				gameSettings->setDefaultResources(false);

--- a/source/shared_lib/include/platform/sdl/platform_main.h
+++ b/source/shared_lib/include/platform/sdl/platform_main.h
@@ -251,7 +251,7 @@ void printParameterHelp(const char *argv0, bool foundInvalidArgs) {
 	printf("\n%s=x\t\t\tAuto load a mod by mod pathname.",GAME_ARGS[GAME_ARG_MOD]);
 
 	//     "================================================================================"
-	printf("\n%s=x\t\t\tAuto Preview a map by map name.",GAME_ARGS[GAME_ARG_PREVIEW_MAP]);
+	printf("\n%s=Map,Tileset\tAuto Preview a map by map name. (tileset is optional)",GAME_ARGS[GAME_ARG_PREVIEW_MAP]);
 	printf("\n%s\t\t\tdisplays the version string of this program.",GAME_ARGS[GAME_ARG_VERSION]);
 	printf("\n%s\t\t\tdisplays your video driver's OpenGL info.",GAME_ARGS[GAME_ARG_OPENGL_INFO]);
 	printf("\n%s\t\t\tdisplays your SDL version information.",GAME_ARGS[GAME_ARG_SDL_INFO]);


### PR DESCRIPTION
Tell the game a specific tileset to use together with the --preview-map
option. The Tileset is optional. Default is forest.
! EVEN IF FOREST DOES NOT EXIST ! (like before)
./start_megaglest --preview-map=Map,Tileset