### PR TITLE
close opened file descriptors properly

### DIFF
--- a/source/shared_lib/sources/map/map_preview.cpp
+++ b/source/shared_lib/sources/map/map_preview.cpp
@@ -827,6 +827,7 @@ void MapPreview::loadFromFile(const string &path) {
 		if(bytes != 1) {
 			char szBuf[8096]="";
 			snprintf(szBuf,8096,"fread returned wrong size = " MG_SIZE_T_SPECIFIER " on line: %d.",bytes,__LINE__);
+			fclose(f1);
 			throw megaglest_runtime_error(szBuf);
 		}
 		fromEndianMapFileHeader(header);


### PR DESCRIPTION
:bug: label: [hacktoberfest](https://hacktoberfest.digitalocean.com)

Greetings,

Calling `fclose(f1);` here will ensure the file descriptor is properly disposed of and we will not run out of resources for more files. Even if it's closed automatically by the system when exiting the process, we believe you should release `f1` when done with it.

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com
