### PR TITLE
Shorten indicator for headless server mode

### DIFF
--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -742,7 +742,7 @@ string MenuStateCustomGame::createGameName(string controllingPlayer){
 		if (controllingPlayer != "") {
 			return controllingPlayer + " controls";
 		} else {
-			return "Headless (" + defaultPlayerName + ")";
+			return "[H] " + defaultPlayerName;
 		}
 	} else {
 		string defaultPlayerNameEnd = defaultPlayerName.substr(defaultPlayerName.size()-1, 1);


### PR DESCRIPTION
"Headless (servername)" is really long. https://forum.megaglest.org/?topic=9965 requests for it to be shorted.
Changing this means that the masterserver code interpreting this 'tag' also needs to be edited.