### PR TITLE
ircclient.cpp:correct spelling

### DIFF
--- a/source/shared_lib/sources/platform/posix/ircclient.cpp
+++ b/source/shared_lib/sources/platform/posix/ircclient.cpp
@@ -825,7 +825,7 @@ void IRCThread::execute() {
             if(SystemFlags::VERBOSE_MODE_ENABLED || IRCThread::debugEnabled) printf ("===> IRC: Line: %d\n", __LINE__);
 
             safeMutex.Lock();
-            if(irc_connect(ircSession, argv[0].c_str(), IRC_SERVER_PORT, 0, this->nick.c_str(), this->username.c_str(), ("MegagGlest "+glestVersionString).c_str())) {
+            if(irc_connect(ircSession, argv[0].c_str(), IRC_SERVER_PORT, 0, this->nick.c_str(), this->username.c_str(), ("MegaGlest "+glestVersionString).c_str())) {
             	safeMutex.ReleaseLock();
                 if(SystemFlags::VERBOSE_MODE_ENABLED || IRCThread::debugEnabled) printf ("===> IRC Could not connect: %s\n", irc_strerror (irc_errno(ircSession)));
                 return;


### PR DESCRIPTION
removed the unnecessary "g"