### PR TITLE
prevent units from interrupting (cancelling) building construction

### DIFF
--- a/source/glest_game/graphics/renderer.cpp
+++ b/source/glest_game/graphics/renderer.cpp
@@ -5288,7 +5288,7 @@ void Renderer::renderGhostModel(const UnitType *building, const Vec2i pos,Cardin
 		color = *forceColor;
 	}
 	else {
-		if(map->isFreeCells(pos, building->getSize(), fLand)) {
+		if(map->isFreeCells(pos, building->getSize(), fLand, true)) {
 			color= Vec4f(1.f, 1.f, 1.f, 0.5f);
 		}
 		else {

--- a/source/glest_game/world/map.cpp
+++ b/source/glest_game/world/map.cpp
@@ -765,11 +765,11 @@ bool Map::isResourceNear(int frameIndex,const Vec2i &pos, const ResourceType *rt
 
 // ==================== free cells ====================
 
-bool Map::isFreeCell(const Vec2i &pos, Field field) const {
+bool Map::isFreeCell(const Vec2i &pos, Field field, bool buildingsOnly) const {
 	return
 		isInside(pos) &&
 		isInsideSurface(toSurfCoords(pos)) &&
-		getCell(pos)->isFree(field) &&
+		(getCell(pos)->isFree(field) ? true : (buildingsOnly && !getCell(pos)->getUnit(field)->getType()->hasSkillClass(scBeBuilt))) &&
 		(field==fAir || getSurfaceCell(toSurfCoords(pos))->isFree()) &&
 		(field!=fLand || getDeepSubmerged(getCell(pos)) == false);
 }
@@ -843,11 +843,11 @@ bool Map::isAproxFreeCell(const Vec2i &pos, Field field, int teamIndex) const {
 	return false;
 }
 
-bool Map::isFreeCells(const Vec2i & pos, int size, Field field) const  {
+bool Map::isFreeCells(const Vec2i & pos, int size, Field field, bool buildingsOnly) const {
 	for(int i=pos.x; i<pos.x+size; ++i) {
 		for(int j=pos.y; j<pos.y+size; ++j) {
 			Vec2i testPos(i,j);
-			if(isFreeCell(testPos, field) == false) {
+			if (isFreeCell(testPos, field, buildingsOnly) == false) {
 				return false;
 			}
 		}
@@ -1417,9 +1417,10 @@ void Map::putUnitCellsPrivate(Unit *unit, const Vec2i &pos, const UnitType *ut, 
 //                    }
 				}
 
-
 				if(getCell(currPos)->getUnit(field) == NULL ||
-								   getCell(currPos)->getUnit(field) == unit) {
+				    getCell(currPos)->getUnit(field) == unit ||
+				    (unit->getType()->hasSkillClass(scBeBuilt) != getCell(currPos)->getUnit(field)->getType()->hasSkillClass(scBeBuilt))) {
+
 					if(isMorph) {
 						// unit is beeing morphed to another unit with maybe other field.
 						getCell(currPos)->setUnit(field, unit);

--- a/source/glest_game/world/map.h
+++ b/source/glest_game/world/map.h
@@ -325,10 +325,10 @@ public:
 	bool isResourceNear(int frameIndex,const Vec2i &pos, const ResourceType *rt, Vec2i &resourcePos, int size, Unit *unit=NULL,bool fallbackToPeersHarvestingSameResource=false,Vec2i *resourceClickPos=NULL) const;
 
 	//free cells
-	bool isFreeCell(const Vec2i &pos, Field field) const;
+	bool isFreeCell(const Vec2i &pos, Field field, bool buildingsOnly = false) const;
 	bool isFreeCellOrHasUnit(const Vec2i &pos, Field field, const Unit *unit) const;
 	bool isAproxFreeCell(const Vec2i &pos, Field field, int teamIndex) const;
-	bool isFreeCells(const Vec2i &pos, int size, Field field) const;
+	bool isFreeCells(const Vec2i &pos, int size, Field field, bool buildingsOnly = false) const;
 	bool isFreeCellsOrHasUnit(const Vec2i &pos, int size, Field field, const Unit *unit) const;
 	bool isAproxFreeCells(const Vec2i &pos, int size, Field field, int teamIndex) const;
 	bool canMorph(const Vec2i &pos,const Unit *currentUnit,const UnitType *targetUnitType ) const;

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -1140,7 +1140,7 @@ void UnitUpdater::updateBuild(Unit *unit, int frameIndex) {
 				switch(this->game->getGameSettings()->getPathFinderType()) {
 					case pfBasic:
 						if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled) SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d] tsArrived about to call map->isFreeCells() for command->getPos() = %s, ut->getSize() = %d\n",__FILE__,__FUNCTION__,__LINE__,command->getPos().getString().c_str(),ut->getSize());
-						canOccupyCell = map->isFreeCells(command->getPos(), ut->getSize(), fLand);
+						canOccupyCell = map->isFreeCells(command->getPos(), ut->getSize(), fLand, true);
 						break;
 					default:
 						throw megaglest_runtime_error("detected unsupported pathfinder type!");


### PR DESCRIPTION
This is a patch @mathusummut did for @Zetaglest in
https://github.com/zetaglest/zetaglest-source/commit/bbc97d02bb5f51b1f3642204a3d9f40db83cce10
and
https://github.com/zetaglest/zetaglest-source/commit/8117d96c639866a38ff622ca1735a52cbae012e0

Here is a video that demonstrates it (sorry it's not a very efficient
demo) https://www.twitch.tv/videos/379850083##