### PR TITLE
Chat/Console message appears when a building is completed

### DIFF
--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -2043,6 +2043,12 @@ void Unit::born(const CommandType *ct) {
 	faction->applyStaticProduction(type,ct);
 	setCurrSkill(scStop);
 
+	if(ct != NULL && (ct->getClass() == ccBuild || ct->getClass() == ccRepair)) {
+		//assume this is a building. This could lead to problems in the future,
+		//but there is no real way to detect a building
+		game->getConsole()->addStdMessage("BuildingFinished",": " + formatString(getFullName(true)));
+	}
+
 	checkItemInVault(&this->hp,this->hp);
 	int original_hp = this->hp;
 


### PR DESCRIPTION
Displaying a message on chat/console when a building finishes.
Any more ideas? I would add them here, before we accept the pull request.
Also see https://forum.megaglest.org/index.php?topic=9721.0