### PR TITLE
Update setupBuildDeps.sh

### DIFF
--- a/mk/linux/setupBuildDeps.sh
+++ b/mk/linux/setupBuildDeps.sh
@@ -114,7 +114,7 @@ fi
 packages_for_next_debian_ubuntu_mint="build-essential cmake libcurl4-gnutls-dev libsdl2-dev libopenal-dev liblua5.3-dev libjpeg-dev libpng-dev libfreetype6-dev libwxgtk3.0-dev libcppunit-dev libfribidi-dev libftgl-dev libglew-dev libogg-dev libvorbis-dev libminiupnpc-dev libircclient-dev libvlc-dev libvlccore-dev libxml2-dev libx11-dev libgl1-mesa-dev libglu1-mesa-dev librtmp-dev libkrb5-dev libldap2-dev libidn2-0-dev libpsl-dev libgnutls28-dev libnghttp2-dev libssh2-1-dev"
 
 case $distribution in
-	Debian)
+	Debian|Raspbian)
 		case $release in
 			oldstable|8|8.*)
 				#name > jessie, EoL May 2020


### PR DESCRIPTION
Adding support for Raspbian (I installed all the dependencies for compiling Megaglest on Raspberry Pi 4 by simply substituting Debian with Raspbian in this script, as they are, essentially, the same system; it worked without any additional tweaks).