### PR TITLE
Replace some http links with https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ IF("${CPACK_GENERATOR}" STREQUAL "NSIS")
 	SET(CPACK_NSIS_DISPLAY_NAME "MegaGlest")
 	SET(CPACK_NSIS_MUI_ICON "${PROJECT_SOURCE_DIR}/mk/windoze/glest.ico")
 	SET(CPACK_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/mk/windoze/megaglest.ico")
-	SET(CPACK_NSIS_URL_INFO_ABOUT "http://megaglest.org")
+	SET(CPACK_NSIS_URL_INFO_ABOUT "https://megaglest.org")
 ENDIF()
 
 INCLUDE(CPack)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ within the game at no cost.
 [**MegaGlest Downloads**](https://megaglest.org/download.html)
 
 ![gif](https://megaglest.org/uploads/images/screenshots/game_screens.gif)
-[> game trailer <](http://downloads.megaglest.org/videos/megaglest_game_trailer_lq.webm)
+[> game trailer <](https://downloads.megaglest.org/videos/megaglest_game_trailer_lq.webm)
 
 If you want to compile MegaGlest yourself, you should read the following:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 **This is the game engine source code repository.**
 
-MegaGlest (http://megaglest.org) is a libre software cross
+MegaGlest (https://megaglest.org) is a libre software cross
 platform real-time strategy game.
 
-![logo](http://megaglest.org/uploads/megaglest2011/logo/logo.png)
+![logo](https://megaglest.org/uploads/megaglest2011/logo/logo.png)
 
 MegaGlest is an entertaining free (freeware and free software)
 and open source cross-platform 3D real-time strategy (RTS) game,
@@ -14,9 +14,9 @@ like the unit models, are crafted with great attention to
 detail. A lot of additional game data can be downloaded from
 within the game at no cost.
 
-[**MegaGlest Downloads**](http://megaglest.org/download.html)
+[**MegaGlest Downloads**](https://megaglest.org/download.html)
 
-![gif](http://megaglest.org/uploads/images/screenshots/game_screens.gif)
+![gif](https://megaglest.org/uploads/images/screenshots/game_screens.gif)
 [> game trailer <](http://downloads.megaglest.org/videos/megaglest_game_trailer_lq.webm)
 
 If you want to compile MegaGlest yourself, you should read the following:

--- a/docs/README.compiling-linux.txt
+++ b/docs/README.compiling-linux.txt
@@ -10,7 +10,7 @@
 Developed on Linux with glibc, little endian CPU. While MacIntel builds exist
 (for some versions of the game), MegaGlest does not currently work on big
 endian CPUs like PPC (though some unfinished patches for vanilla Glest float
-around on the forums, e.g. http://forum.megaglest.org/?topic=1426#).
+around on the forums, e.g. https://forum.megaglest.org/?topic=1426#).
 
 ~~~~~~~~~~~~~~~~~~~~~~ 2. Building and Installation ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/README.compiling-linux.txt
+++ b/docs/README.compiling-linux.txt
@@ -131,7 +131,7 @@ BSD distributions. Please see the website, forums and wiki for details.
   AMD APUs (the graphics chips embedded into AMD processors).
 
 --- Crashing ---
-* Check the forums at http://forums.megaglest.org/
+* Check the forums at https://forums.megaglest.org/
 * Please report any crashes and freezes that are not yet described on the forums, 
   preferably with a gdb backtrace from a debugging enabled build 
   (cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo)
@@ -146,7 +146,7 @@ BSD distributions. Please see the website, forums and wiki for details.
   https://docs.megaglest.org/Main_Page
 
 * Forums
-  http://forums.megaglest.org/
+  https://forums.megaglest.org/
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 5. Contact + Credits ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * MegaGlest is developed by:

--- a/docs/README.compiling-windows.txt
+++ b/docs/README.compiling-windows.txt
@@ -114,7 +114,7 @@ directory tree the %AppData% environment variable points to.
 * Try to get updated graphics drivers.
 
 -- The game crashes ---
-* Check the forums at http://forums.megaglest.org/
+* Check the forums at https://forums.megaglest.org/
 * Please report any other crashes and freezes that are not yet described on 
   the forums, preferably with a backtrace from a debugging enabled build
   
@@ -127,7 +127,7 @@ directory tree the %AppData% environment variable points to.
   https://docs.megaglest.org/Main_Page
 
 * Forums
-  http://forums.megaglest.org/
+  https://forums.megaglest.org/
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 5. Contact + Credits ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * MegaGlest is developed by:

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -259,7 +259,7 @@ megaglest --help
 Further information:
 
 - The MegaGlest website:
-  http://megaglest.org
+  https://megaglest.org
 
 - The MegaGlest wiki:
   http://wiki.megaglest.org

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -278,7 +278,7 @@ their own by reading up on available documentation before getting in touch.
 
 - Post to the forums:
   If you are reporting a bug, please be sure to read the bug reporting guide.
-  http://forum.megaglest.org
+  https://forum.megaglest.org
 
 - Contact us on IRC:
   Network: irc.libera.chat

--- a/mk/linux/tools-for-standalone-client/installer/scripts/config.lua
+++ b/mk/linux/tools-for-standalone-client/installer/scripts/config.lua
@@ -64,7 +64,7 @@ Setup.Package
 
     postinstall = function(package)
 	if MojoSetup.promptyn(_("MegaGlest Visit Website Title"), _("MegaGlest Visit Website Prompt")) then
-        	MojoSetup.launchbrowser("https://megaglest.org/get-started.html")
+        	MojoSetup.launchbrowser("https://megaglest.org/get_started")
 	end
     end,
 

--- a/mk/linux/tools-for-standalone-client/installer/scripts/config.lua
+++ b/mk/linux/tools-for-standalone-client/installer/scripts/config.lua
@@ -64,7 +64,7 @@ Setup.Package
 
     postinstall = function(package)
 	if MojoSetup.promptyn(_("MegaGlest Visit Website Title"), _("MegaGlest Visit Website Prompt")) then
-        	MojoSetup.launchbrowser("http://megaglest.org/get-started.html")
+        	MojoSetup.launchbrowser("https://megaglest.org/get-started.html")
 	end
     end,
 

--- a/mk/windoze/Installer/MegaGlestInstaller.nsi
+++ b/mk/windoze/Installer/MegaGlestInstaller.nsi
@@ -195,7 +195,7 @@ FunctionEnd
 Function .onInstSuccess
 
     MessageBox MB_YESNO "Would you like to view our getting started page on megaglest.org?" IDNO noLaunchWebsite
-    ExecShell open 'https://megaglest.org/get-started.html'
+    ExecShell open 'https://megaglest.org/get_started'
     
 noLaunchWebsite:
 

--- a/mk/windoze/Installer/MegaGlestInstaller.nsi
+++ b/mk/windoze/Installer/MegaGlestInstaller.nsi
@@ -195,7 +195,7 @@ FunctionEnd
 Function .onInstSuccess
 
     MessageBox MB_YESNO "Would you like to view our getting started page on megaglest.org?" IDNO noLaunchWebsite
-    ExecShell open 'http://megaglest.org/get-started.html'
+    ExecShell open 'https://megaglest.org/get-started.html'
     
 noLaunchWebsite:
 

--- a/mk/windoze/Installer/make_installer.sh
+++ b/mk/windoze/Installer/make_installer.sh
@@ -9,8 +9,8 @@ cd "$CURRENTDIR"
 
 # We need the AccessControl plugin for nsis and place this in plugins directory
 # original from http://nsis.sourceforge.net/AccessControl_plug-in
-wget http://downloads.megaglest.org/windowsInstallerHelp/AccessControl.dll -P plugins
-wget http://downloads.megaglest.org/windowsInstallerHelp/AccessControl.txt -P plugins
+wget https://downloads.megaglest.org/windowsInstallerHelp/AccessControl.dll -P plugins
+wget https://downloads.megaglest.org/windowsInstallerHelp/AccessControl.txt -P plugins
 
 makensis MegaGlestInstaller.nsi
 

--- a/source/tools/support/linux/system_report
+++ b/source/tools/support/linux/system_report
@@ -84,7 +84,7 @@ common_info () {
     echo "  sudo find -type f -name $Exec_2 /" >&2
     echo >&2
     echo "Please be aware that this script is written to work with installations created" >&2
-    echo "using the installation instructions on http://megaglest.org. It may or may not" >&2
+    echo "using the installation instructions on https://megaglest.org. It may or may not" >&2
     echo "work with variants of MegaGlest which were packaged by your Linux distribution." >&2
     echo >&2; exit 1
 }

--- a/source/tools/support/linux/system_report
+++ b/source/tools/support/linux/system_report
@@ -386,7 +386,7 @@ echo ' take note of this new location/URL/Internet address and make it available
 echo ' the MegaGlest developers. Unless you were instructed to do otherwise, please'
 echo ' post both the Internet address of where you uploaded to and a verbose'
 echo ' description of the issues you are experiencing at'
-echo '   http://forum.megaglest.org'
+echo '   https://forum.megaglest.org'
 echo ''
 echo ' Thank you for making it easy for us to assist you,'
 echo ''


### PR DESCRIPTION
There are already some documents in this repo which link to the https variant. This eliminates the inconsistency and replaces all the http links which are known to work with https with the more secure counterpart. https is both more secure and faster.

However, there are some links I could not replace because they appear to be redirects and the webserver does not have a https setup for them.

- [x] forum(s).megaglest.org
- [x] megaglest.org
- [x] docs.megaglest.org
- [ ] wiki.megaglest.org
- [ ] master.megaglest.org **Note:** Has working https in browser but it appears in config files only and might break the client if I do replace these. Though it would be super awesome if communication from the client could use https.
- [ ] faq.megaglest.org
- [ ] chat.megaglest.org
- [x] downloads.megaglest.org
- [ ] status.megaglest.org
- [ ] paste.megaglest.org
- Possibly more redirects I am too lazy to list