### PR TITLE
Make command queuing behave more like other RTS games

### DIFF
--- a/source/glest_game/type_instances/command.cpp
+++ b/source/glest_game/type_instances/command.cpp
@@ -76,12 +76,6 @@ Command::Command(const CommandType *ct, const Vec2i &pos, const UnitType *unitTy
 	//}
 }
 
-int Command::getPriority(){
-	if(this->commandType->commandTypeClass==ccAttack && getUnit()==NULL){
-		return 5; // attacks to the ground have low priority
-	}
-	return this->commandType->getTypePriority();
-}
 // =============== set ===============
 
 void Command::setCommandType(const CommandType *commandType) {

--- a/source/glest_game/type_instances/command.h
+++ b/source/glest_game/type_instances/command.h
@@ -71,9 +71,6 @@ public:
 	inline const UnitType* getUnitType() const			{return unitType;}
 	inline CardinalDir getFacing() const				{return facing;}
 	
-	//Priority: commands of higher priority will cancel commands of lower priority
-	virtual int getPriority();
-	
     //set 
     void setCommandType(const CommandType *commandType);
     void setPos(const Vec2i &pos);

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -1828,8 +1828,6 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
     	throw megaglest_runtime_error("command->getCommandType() == NULL");
     }
 
-    const int command_priority = command->getPriority();
-
     if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 
     //printf("In [%s::%s] Line: %d unit [%d - %s] command [%s] tryQueue = %d command->getCommandType()->isQueuable(tryQueue) = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,this->getId(),this->getType()->getName().c_str(), command->getCommandType()->getName().c_str(), tryQueue,command->getCommandType()->isQueuable(tryQueue));
@@ -1839,32 +1837,6 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled) SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d] Command is Queable\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__);
 
-		if(command->getCommandType()->isQueuable() == qAlways && tryQueue){
-			// Its a produce or upgrade command called without queued key
-			// in this case we must NOT delete lower priority commands!
-			// we just queue it!
-
-		}
-		else {
-			//Delete all lower-prioirty commands
-			for(list<Command*>::iterator i= commands.begin(); i != commands.end();){
-				if((*i)->getPriority() < command_priority){
-					if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled)
-						SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d] Deleting lower priority command [%s]\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,(*i)->toString(false).c_str());
-
-					static string mutexOwnerId = string(__FILE__) + string("_") + intToStr(__LINE__);
-					MutexSafeWrapper safeMutex(mutexCommands,mutexOwnerId);
-
-					deleteQueuedCommand(*i);
-					i= commands.erase(i);
-
-					safeMutex.ReleaseLock();
-				}
-				else {
-					++i;
-				}
-			}
-		}
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 
 		//cancel current command if it is not queuable

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -108,8 +108,6 @@ public:
 		Queueability q = isQueuable();
 		return (q != qNever) && (q != qOnlyLast);
 	}
-	//Priority: commands of higher priority will cancel commands of lower priority
-	virtual int getTypePriority() const {return 10;}
 	virtual bool usesPathfinder() const= 0;
 
     //get
@@ -139,7 +137,6 @@ public:
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
 	virtual string toString(bool translatedValue) const;
 	virtual Queueability isQueuable() const						{return qNever;}
-	virtual int getTypePriority() const							{return 100000;}
     //get
 	const StopSkillType *getStopSkillType() const	{return stopSkillType;};
 
@@ -213,6 +210,7 @@ public:
     		const TechTree *tt, const FactionType *ft, const UnitType &ut,
     		std::map<string,vector<pair<string, string> > > &loadedFileList, string parentLoader);
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
+	virtual Queueability isQueuable() const	{return qOnlyLast;}
 	virtual string toString(bool translatedValue) const;
 
     //get
@@ -369,7 +367,6 @@ public:
 	virtual string toString(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
 	virtual Queueability isQueuable() const						{return qAlways;}
-	virtual int getTypePriority() const {return 15;}
 
     //get
 	const ProduceSkillType *getProduceSkillType() const	{return produceSkillType;}
@@ -399,7 +396,6 @@ public:
 	virtual string getReqDesc(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
 	virtual Queueability isQueuable() const						{return qAlways;}
-	virtual int getTypePriority() const {return 15;}
 
     //get
 	const UpgradeSkillType *getUpgradeSkillType() const		{return upgradeSkillType;}

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -720,20 +720,6 @@ void UnitUpdater::updateAttack(Unit *unit, int frameIndex) {
 
 	if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s Line: %d] took msecs: %lld\n",__FILE__,__FUNCTION__,__LINE__,chrono.getMillis());
 
-	if( (command->getUnit() == NULL || !(command->getUnit()->isAlive()) ) && unit->getCommandSize() > 1) {
-
-		if(frameIndex < 0) {
-			unit->finishCommand(); // all queued "ground attacks" are skipped if somthing else is queued after them.
-
-			if(SystemFlags::getSystemSettingType(SystemFlags::debugWorldSynch).enabled == true && frameIndex < 0) {
-				char szBuf[8096]="";
-				snprintf(szBuf,8096,"[updateAttack]");
-				unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(),__LINE__,szBuf);
-			}
-		}
-		return;
-	}
-
 	//if found
 	//if(frameIndex < 0) {
 	{


### PR DESCRIPTION
...by removing the command priority system

The command priority system was resulting in non-intuitive and surprising behaviour when queuing
commands. Removing this system results in Megaglest behaving more like
other RTS games.

For instance, the following are now possible and weren't previously:
- Queuing multiple attack ground commands to move along a specific path
attacking all enemies on the way.
- Queuing attack ground followed by hold position, which is a sensible
  thing to do if you want a unit to guard a specific area.
- Queuing a move command followed by a produce command, if you want to
  have your summoner summon a daemon at a specific location.

The behaviour of queuing the stop command is unchanged, and commands that
must be the last in the queue, such as morphing, are still properly replaced when something
else is queued.