### PR TITLE
Add camera location hotkeys

### DIFF
--- a/mk/shared/glestkeys.ini
+++ b/mk/shared/glestkeys.ini
@@ -26,6 +26,10 @@ GroupUnitsKey7='6'
 GroupUnitsKey8='7'
 GroupUnitsKey9='8'
 GroupUnitsKey10='9'
+CameraLocationKey1=f1
+CameraLocationKey2=f2
+CameraLocationKey3=f3
+CameraLocationKey4=f4
 CameraRotateLeft=A
 CameraRotateRight=D
 CameraRotateUp=S
@@ -47,11 +51,11 @@ ToggleMusic=K
 SaveGUILayout=f10
 SetMarker=X
 ReloadINI=f5
-TogglePhotoMode=f8
+TogglePhotoMode=f6
 SwitchLanguage=L
 SaveGame=f11
-BookmarkAdd=f2
-BookmarkRemove=f3
-CameraFollowSelectedUnit=f4
+BookmarkAdd=f7
+BookmarkRemove=f8
+CameraFollowSelectedUnit=f9
 ; === propertyMap File === 
 

--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -4890,6 +4890,18 @@ void Game::keyDown(SDL_KeyboardEvent key) {
 			//hotkeys
 			if(SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem,"In [%s::%s Line: %d] gameCamera.getState() = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,gameCamera.getState());
 
+			for (int i = 0; i < 4; i++) {
+				string keyName = "CameraLocationKey" + intToStr(i+1);
+
+				if (isKeyPressed(configKeys.getSDLKey(keyName.c_str()),key) == true) {
+					if (isKeyDown(vkControl)) {
+						gameCamera.saveLocation(i);
+					} else {
+						gameCamera.restoreLocation(i);
+					}
+				}
+			}
+
 			if(gameCamera.getState() != GameCamera::sFree){
 				if(SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem,"In [%s::%s Line: %d] key = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,key);
 

--- a/source/glest_game/game/game_camera.h
+++ b/source/glest_game/game/game_camera.h
@@ -60,6 +60,7 @@ public:
 	};
 
 private:
+	map <int,Vec2f> locations;
 	Vec3f pos;
 	Vec3f destPos;
 	Vec2f shakeOffset;
@@ -175,6 +176,9 @@ public:
 	void saveGame(XmlNode *rootNode);
 	void loadGame(const XmlNode *rootNode);
 
+	void restoreLocation(int i) { try { setPos(locations.at(i)); } catch (const std::out_of_range& oor) {} }
+	void saveLocation(int i) { locations[i] = Vec2f(getPos().x,getPos().z); }
+
 private:
 	//void setClampBounds(bool value) { clampBounds = value; }
 	void resetPosition();
@@ -185,6 +189,7 @@ private:
 	void moveUp(float dist);
 	void rotateHV(float h, float v);
 	void shakeCamera();
+
 };
 
 }} //end namespace


### PR DESCRIPTION
Done:

- you can save and restore the camera location using hotkeys.

~~- Calculate and restore the camera pivot point instead of the location to improve the UX when the user has rotated or zoomed the camera.~~ the camera already  rotates around the position instead of  the center point, ideally this should be changed. #234
fixes #224
