### PR TITLE
Control group hotkeys

### DIFF
--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -364,15 +364,8 @@ void Gui::mouseDoubleClickLeftGraphics(int x, int y){
 void Gui::groupKey(int groupIndex) {
 	if(isKeyDown(vkControl) || isKeyDown(vkAlt)){
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem,"In [%s::%s Line: %d] groupIndex = %d\n",__FILE__,__FUNCTION__,__LINE__,groupIndex);
-//		bool allAssigned=true;
 		bool clearGroup=!isKeyDown(vkShift);
 		bool move=isKeyDown(vkAlt) && !isKeyDown(vkControl);
-//		if(!clearGroup){
-//			Unit* unit=selection.getFrontUnit();
-//			if(unit!=null && unit->getType()->getMultiSelect()==false){
-//				return;
-//			}
-//		}
 		bool allAssigned=selection.assignGroup(groupIndex,!move && clearGroup, move);
 		if(!allAssigned){
 			console->addStdMessage("GroupAssignFailed");

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -362,17 +362,18 @@ void Gui::mouseDoubleClickLeftGraphics(int x, int y){
 }
 
 void Gui::groupKey(int groupIndex) {
-	if(isKeyDown(vkControl)){
+	if(isKeyDown(vkControl) || isKeyDown(vkAlt)){
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem,"In [%s::%s Line: %d] groupIndex = %d\n",__FILE__,__FUNCTION__,__LINE__,groupIndex);
 //		bool allAssigned=true;
 		bool clearGroup=!isKeyDown(vkShift);
+		bool move=isKeyDown(vkAlt) && !isKeyDown(vkControl);
 //		if(!clearGroup){
 //			Unit* unit=selection.getFrontUnit();
 //			if(unit!=null && unit->getType()->getMultiSelect()==false){
 //				return;
 //			}
 //		}
-		bool allAssigned=selection.assignGroup(groupIndex,clearGroup);
+		bool allAssigned=selection.assignGroup(groupIndex,!move && clearGroup, move);
 		if(!allAssigned){
 			console->addStdMessage("GroupAssignFailed");
 		}

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -364,9 +364,9 @@ void Gui::mouseDoubleClickLeftGraphics(int x, int y){
 void Gui::groupKey(int groupIndex) {
 	if(isKeyDown(vkControl) || isKeyDown(vkAlt)){
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem,"In [%s::%s Line: %d] groupIndex = %d\n",__FILE__,__FUNCTION__,__LINE__,groupIndex);
-		bool clearGroup=!isKeyDown(vkShift);
-		bool move=isKeyDown(vkAlt) && !isKeyDown(vkControl);
-		bool allAssigned=selection.assignGroup(groupIndex,!move && clearGroup, move);
+		bool move=isKeyDown(vkAlt);
+		bool clearGroup= move && isKeyDown(vkControl) || !move && isKeyDown(vkShift);
+		bool allAssigned=selection.assignGroup(groupIndex,clearGroup, move);
 		if(!allAssigned){
 			console->addStdMessage("GroupAssignFailed");
 		}

--- a/source/glest_game/gui/selection.cpp
+++ b/source/glest_game/gui/selection.cpp
@@ -227,7 +227,7 @@ bool Selection::hasUnit(const Unit* unit) const {
 	return find(selectedUnits.begin(), selectedUnits.end(), unit) != selectedUnits.end();
 }
 
-bool Selection::assignGroup(int groupIndex, bool clearGroup,const UnitContainer *pUnits) {
+bool Selection::assignGroup(int groupIndex, bool clearGroup, bool move, const UnitContainer *pUnits) {
 	if(groupIndex < 0 || groupIndex >= maxGroups) {
 		throw megaglest_runtime_error("Invalid value for groupIndex = " + intToStr(groupIndex));
 	}
@@ -244,6 +244,11 @@ bool Selection::assignGroup(int groupIndex, bool clearGroup,const UnitContainer 
 	}
 
 	for(unsigned int i = 0; i < addUnits->size(); ++i) {
+		if (move) {
+			for (unsigned int g = 0; g < maxGroups; g++) {
+				removeUnitFromGroup(g,(*addUnits)[i]->getId());
+			}
+		}
 		if(false == addUnitToGroup(groupIndex,(*addUnits)[i])){
 			// don't try to add more, group is maybe full
 			return false;

--- a/source/glest_game/gui/selection.h
+++ b/source/glest_game/gui/selection.h
@@ -89,7 +89,7 @@ public:
 	Vec3f getRefPos() const;
 	bool hasUnit(const Unit* unit) const;
 	
-	bool assignGroup(int groupIndex, bool clearGroup=true, const UnitContainer *pUnits=NULL);
+	bool assignGroup(int groupIndex, bool clearGroup=true, bool move=false, const UnitContainer *pUnits=NULL);
 	bool addUnitToGroup(int groupIndex,Unit *unit);
 	void removeUnitFromGroup(int groupIndex,int UnitId);
 	void recallGroup(int groupIndex, bool clearSelection=true);


### PR DESCRIPTION
- Control+shift+groupKey already *adds* the selected units into the group
- alt+groupKey now removes the units from all the groups and *adds* them into the group
- control+alt+groupKey now removes the units from all the groups and creates a new group with them

the controlscheme was taken from Starcraft 2

partially fixes #223 (there's no hotkey to only remove, but I think that alt is good enough)

Improvements:

- Honestly Control+shift+groupKey is hard to press, I'd change it to shift+groupKey
- the modifiers should be customizable instead of being hardcoded (#230)
