### PR TITLE
Add clickable unit portraits

### DIFF
--- a/source/glest_game/gui/display.cpp
+++ b/source/glest_game/gui/display.cpp
@@ -112,6 +112,24 @@ int Display::computeDownIndex(int x, int y) const {
 	return index;
 }
 
+int Display::computeUpIndex(int x, int y) const {
+	y= y-(Metrics::getInstance().getDisplayH()-upCellSideCount*upImageSize);
+	
+	if(y>imageSize*upCellSideCount || y < 0){
+		return invalidPos;
+	}
+
+	int cellX= x/upImageSize;
+	int cellY= (y/upImageSize) % upCellSideCount;
+	int index= (upCellSideCount-cellY-1)*upCellSideCount+cellX;;
+
+	if(index<0 || index>=upCellCount || upImages[index]==NULL){
+		index= invalidPos;
+	}
+
+	return index;
+}
+
 int Display::computeDownX(int index) const{
 	return (index % cellSideCount) * imageSize;
 }

--- a/source/glest_game/gui/display.h
+++ b/source/glest_game/gui/display.h
@@ -105,6 +105,7 @@ public:
 	void clear();
 	void switchColor();
 	int computeDownIndex(int x, int y) const;
+	int computeUpIndex(int x, int y) const;
 	int computeDownX(int index) const;
 	int computeDownY(int index) const;
 	int computeUpX(int index) const;

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -654,7 +654,9 @@ void Gui::clickCommonCommand(CommandClass commandClass) {
 
 void Gui::mouseDownPortrait(int posDisplay) {
 	Unit *unit = selection.getUnitPtr(posDisplay);
-	if (!isKeyDown(vkShift)) {
+	if (isKeyDown(vkControl)) {
+		selection.selectType(unit);
+	} else if (!isKeyDown(vkShift)) {
 		selection.clear();
 		selection.select(unit, false);
 	} else {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -102,6 +102,7 @@ Gui::Gui(){
     activeCommandType= NULL;
     activeCommandClass= ccStop;
 	selectingBuilding= false;
+	hoveringUnitPortrait= false;
 	selectedBuildingFacing = CardinalDir(CardinalDir::NORTH);
 	selectingPos= false;
 	selectingMeetingPoint= false;
@@ -203,6 +204,7 @@ void Gui::invalidatePosObjWorld(){
 
 void Gui::resetState(){
     selectingBuilding= false;
+	hoveringUnitPortrait= false;
 	selectedBuildingFacing = CardinalDir(CardinalDir::NORTH);
 	selectingPos= false;
 	selectingMeetingPoint= false;
@@ -237,7 +239,10 @@ void Gui::mouseDownLeftDisplay(int x, int y) {
 		int posDisplay = computePosDisplay(x, y);
 
 		if(posDisplay != invalidPos) {
-			if(selection.isCommandable()) {
+			if (hoveringUnitPortrait) {
+				mouseDownPortrait(posDisplay);
+			} else {
+				if(selection.isCommandable()) {
 
 				if(selectingBuilding) {
 					mouseDownDisplayUnitBuild(posDisplay);
@@ -249,6 +254,7 @@ void Gui::mouseDownLeftDisplay(int x, int y) {
 			else {
 				resetState();
 			}
+            }
 		}
 		computeDisplay();
 	}
@@ -646,6 +652,15 @@ void Gui::clickCommonCommand(CommandClass commandClass) {
 	computeDisplay();
 }
 
+void Gui::mouseDownPortrait(int posDisplay) {
+	Unit *unit = selection.getUnitPtr(posDisplay);
+	if (!isKeyDown(vkShift)) {
+		selection.clear();
+		selection.select(unit, false);
+	} else {
+		selection.unSelect(posDisplay);
+	}
+}
 void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 	if(selection.isEmpty() == false) {
 		if(posDisplay != cancelPos) {
@@ -785,7 +800,7 @@ void Gui::computeInfoString(int posDisplay){
 
 	display.setInfoText(computeDefaultInfoString());
 
-	if(posDisplay!=invalidPos && selection.isCommandable()){
+	if(!hoveringUnitPortrait && posDisplay!=invalidPos && selection.isCommandable()){
 		if(!selectingBuilding){
 			if(posDisplay==cancelPos){
 				display.setInfoText(lang.getString("Cancel"));
@@ -1135,6 +1150,12 @@ int Gui::computePosDisplay(int x, int y){
     }
 
 	//printf("computePosDisplay returning = %d\n",posDisplay);
+	if (posDisplay == invalidPos) {
+		posDisplay = display.computeUpIndex(x, y);
+		if (posDisplay != invalidPos) {
+			hoveringUnitPortrait = true;
+		}
+	}
 
 	return posDisplay;
 }

--- a/source/glest_game/gui/gui.h
+++ b/source/glest_game/gui/gui.h
@@ -139,6 +139,7 @@ private:
 
 	//states
 	bool selectingBuilding;
+	bool hoveringUnitPortrait;
 	bool selectingPos;
 	bool selectingMeetingPoint;
 
@@ -222,6 +223,7 @@ private:
 	int computePosDisplay(int x, int y);
 	void computeDisplay();
 	void resetState();
+	void mouseDownPortrait(int posDisplay);
 	void mouseDownDisplayUnitSkills(int posDisplay);
 	void mouseDownDisplayUnitBuild(int posDisplay);
 	void computeInfoString(int posDisplay);

--- a/source/glest_game/gui/selection.cpp
+++ b/source/glest_game/gui/selection.cpp
@@ -149,6 +149,16 @@ void Selection::select(const UnitContainer &units, bool addToSelection){
 	}
 }
 
+void Selection::selectType(Unit *unit) {
+	UnitContainer units;
+	for (int i = 0; i < (int)selectedUnits.size(); i++) {
+		if (selectedUnits[i]->getType() == unit->getType() && unit->isOperative() == selectedUnits[i]->isOperative() ) {
+			units.push_back(selectedUnits[i]);
+		}
+	}
+	selectedUnits = units;
+}
+
 void Selection::unSelect(const UnitContainer &units) {
 
 	//add units to gui

--- a/source/glest_game/gui/selection.h
+++ b/source/glest_game/gui/selection.h
@@ -69,6 +69,7 @@ public:
 	virtual ~Selection();
 
 	bool select(Unit *unit, bool addToSelection);
+	void selectType(Unit *unit);
 	void select(const UnitContainer &units, bool addToSelection);
 	void unSelect(const UnitContainer &units);
 	void unSelect(int unitIndex);


### PR DESCRIPTION
- clicking on a unit portrait selects that unit
- shift clicking on it, deselects it
- control clicking on it selects all of the units of the same type from  the selection

fixes #222 