### PR TITLE
Feature command queue after morph commands

### DIFF
--- a/source/glest_game/game/commander.cpp
+++ b/source/glest_game/game/commander.cpp
@@ -994,7 +994,8 @@ Command* Commander::buildCommand(const NetworkCommand* networkCommand) const {
 	const UnitType* unitType= world->findUnitTypeById(unit->getFaction()->getType(), networkCommand->getUnitTypeId());
 	
 	if( networkCommand->getUnitTypeId() > -1 &&  networkCommand->getWantQueue()) { //Morph Queue
-		ct = unitType->findCommandTypeById(networkCommand->getCommandTypeId());
+		auto mct = unitType->findCommandTypeById(networkCommand->getCommandTypeId());
+		if(mct) ct = mct;
 	}
 
 	// debug test!

--- a/source/glest_game/game/commander.cpp
+++ b/source/glest_game/game/commander.cpp
@@ -1057,7 +1057,7 @@ Command* Commander::buildCommand(const NetworkCommand* networkCommand) const {
 	//create command
 	Command *command= NULL;
 	if(isCancelPreMorphCommand == false) {
-		if(unitType != NULL) {
+		if(unitType != NULL && ct->getClass() == ccBuild) {
 			command= new Command(ct, networkCommand->getPosition(), unitType, facing);
 		}
 		else if(target == NULL) {

--- a/source/glest_game/game/commander.cpp
+++ b/source/glest_game/game/commander.cpp
@@ -314,15 +314,15 @@ std::pair<CommandResult,string> Commander::tryGiveCommand(const Selection *selec
 			currPos= world->getMap()->computeDestPos(refPos, unit->getPosNotThreadSafe(), pos);
 
 			//get command type
-			const CommandType *commandType= unit->computeCommandType(pos, targetUnit);
+			auto mct= unit->getCurrMorphCt();
+			auto unitType= mct? mct->getMorphUnit(): NULL;
+			const CommandType *commandType= unit->computeCommandType(pos, targetUnit, unitType);
 
 			//give commands
 			if(commandType != NULL) {
 				int targetId= targetUnit==NULL? Unit::invalidId: targetUnit->getId();
 				int unitId= unit->getId();
-				int unitTypeId= -1;
-				auto mct= unit->getCurrMorphCt();
-				if(mct) unitTypeId= mct->getMorphUnit()->getId();
+				int unitTypeId= unitType? unitType->getId(): -1;
 
 				std::pair<CommandResult,string> resultCur(crFailUndefined,"");
 

--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -5005,7 +5005,10 @@ void Game::keyUp(SDL_KeyboardEvent key) {
 				gameCamera.setMoveX(0);
 				camRightButtonDown= false;
 				calcCameraMoveX();
+			} else {
+				gui.hotKeyReleased(key);
 			}
+				
 		}
 	}
 	catch(const exception &ex) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -475,6 +475,8 @@ void Gui::giveOneClickOrders(){
 
 	std::pair<CommandResult,string> result(crFailUndefined,"");
 	bool queueKeyDown = isKeyDown(queueCommandKey);
+	if(activeCommandType && activeCommandType->isQueuable()==qNever && queueKeyDown) return;
+
 	if(selection.isUniform()){
 		result= commander->tryGiveCommand(&selection, activeCommandType, Vec2i(0), (Unit*)NULL,  queueKeyDown);
 	}
@@ -553,7 +555,8 @@ void Gui::giveTwoClickOrders(int x, int y , bool prepared) {
 	}
 
 	bool queueKeyDown = isKeyDown(queueCommandKey);
-    //give orders to the units of this faction
+	if(activeCommandType && activeCommandType->isQueuable()==qNever && queueKeyDown) return;
+	//give orders to the units of this faction
 	if(selectingBuilding == false) {
 		if(selection.isUniform()) {
 			result= commander->tryGiveCommand(&selection, activeCommandType,

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -552,7 +552,7 @@ void Gui::giveTwoClickOrders(int x, int y , bool prepared) {
 		else {
 			result= commander->tryGiveCommand(&selection, activeCommandClass,
 											targetPos, targetUnit,queueKeyDown);
-        	}
+		}
 	}
 	else {
 		//selecting building
@@ -969,6 +969,10 @@ void Gui::computeDisplay(){
 					//uniform selection
 					if(u->isBuilt()){
 						//printf("u->isBuilt()\n");
+						auto mct = u->getCurrMorphCt();
+						if(mct && isKeyDown(queueCommandKey)) {//Morph Queue
+							ut=mct->getMorphUnit();
+						}
 
 						int morphPos= 8;
 						for(int i= 0; i < ut->getCommandTypeCount(); ++i){

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -972,7 +972,7 @@ void Gui::computeDisplay(){
 						auto mct = u->getCurrMorphCt();
 						if(mct && isKeyDown(queueCommandKey)) {//Morph Queue
 							ut=mct->getMorphUnit();
-						}
+						}//TODO subscribe on queueCommandKey presed => resetState() and may remove stop cmd
 
 						int morphPos= 8;
 						for(int i= 0; i < ut->getCommandTypeCount(); ++i){

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -718,7 +718,7 @@ void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 						ct = selection.getUnitFromCC(ccAttack)->getType()->getFirstCtOfClass(activeCommandClass);
 					}
 					auto mct= unit->getCurrMorphCt();
-					if(mct) ct= mct->getMorphUnit()->getFirstCtOfClass(activeCommandClass);
+					if(mct && isKeyDown(queueCommandKey)) ct= mct->getMorphUnit()->getFirstCtOfClass(activeCommandClass);
 
 					if(activeCommandType!=NULL && activeCommandType->getClass()==ccBuild){
 						assert(selection.isUniform());

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -707,6 +707,9 @@ void Gui::mouseDownDisplayUnitSkills(int posDisplay) {
 					if (activeCommandClass  == ccAttack) {
 						ct = selection.getUnitFromCC(ccAttack)->getType()->getFirstCtOfClass(activeCommandClass);
 					}
+					auto mct= unit->getCurrMorphCt();
+					if(mct) ct= mct->getMorphUnit()->getFirstCtOfClass(activeCommandClass);
+
 					if(activeCommandType!=NULL && activeCommandType->getClass()==ccBuild){
 						assert(selection.isUniform());
 						selectingBuilding= true;

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -1006,7 +1006,7 @@ void Gui::computeDisplay(){
 							display.setCommandType(displayPos, ct);
 							display.setCommandClass(displayPos, ct->getClass());
 							bool reqOk=u->getFaction()->reqsOk(ct);
-							display.setDownLighted(displayPos, reqOk && !(!ct->isQueueAppendable() && isKeyDown(queueCommandKey)));
+							display.setDownLighted(displayPos, reqOk && !(ct->isQueuable()==qNever && isKeyDown(queueCommandKey)));
 
 							if (reqOk && produced != NULL) {
 								if (possibleAmount == 0) {

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -447,6 +447,16 @@ void Gui::hotKey(SDL_KeyboardEvent key) {
 	else if(isKeyPressed(configKeys.getSDLKey("HotKeySelectedUnitsStop"),key) == true) {
 		clickCommonCommand(ccStop);
 	}
+	
+	if(isKeyDown(queueCommandKey)) {
+		computeDisplay();
+	}
+}
+
+void Gui::hotKeyReleased(SDL_KeyboardEvent key) {
+	if(!isKeyDown(queueCommandKey)) {
+		computeDisplay();
+	}
 }
 
 void Gui::switchToNextDisplayColor(){
@@ -975,7 +985,7 @@ void Gui::computeDisplay(){
 						auto mct = u->getCurrMorphCt();
 						if(mct && isKeyDown(queueCommandKey)) {//Morph Queue
 							ut=mct->getMorphUnit();
-						}//TODO subscribe on queueCommandKey presed => resetState() and may remove stop cmd
+						}//TODO on queueCommandKey presed disable stop cmd
 
 						int morphPos= 8;
 						for(int i= 0; i < ut->getCommandTypeCount(); ++i){
@@ -996,7 +1006,7 @@ void Gui::computeDisplay(){
 							display.setCommandType(displayPos, ct);
 							display.setCommandClass(displayPos, ct->getClass());
 							bool reqOk=u->getFaction()->reqsOk(ct);
-							display.setDownLighted(displayPos,reqOk);
+							display.setDownLighted(displayPos, reqOk && !(!ct->isQueueAppendable() && isKeyDown(queueCommandKey)));
 
 							if (reqOk && produced != NULL) {
 								if (possibleAmount == 0) {

--- a/source/glest_game/gui/gui.h
+++ b/source/glest_game/gui/gui.h
@@ -196,6 +196,7 @@ public:
 	void mouseDoubleClickLeftGraphics(int x, int y);
 	void groupKey(int groupIndex);
 	void hotKey(SDL_KeyboardEvent key);
+	void hotKeyReleased(SDL_KeyboardEvent key);
 
 	//misc
 	void switchToNextDisplayColor();

--- a/source/glest_game/network/network_types.cpp
+++ b/source/glest_game/network/network_types.cpp
@@ -48,43 +48,52 @@ NetworkCommand::NetworkCommand(World *world, int networkCommandType, int unitId,
 	this->targetId = targetId >= 0 ? targetId : facing;
 	this->fromFactionIndex = world->getThisFactionIndex();
 
-    if(this->networkCommandType == nctGiveCommand) {
-        const Unit *unit= world->findUnitById(this->unitId);
+	if(this->networkCommandType == nctGiveCommand) {
+		const Unit *unit= world->findUnitById(this->unitId);
 
-        //validate unit
-        if(unit != NULL) {
-        	this->unitFactionIndex = unit->getFaction()->getIndex();
-        	this->unitFactionUnitCount = unit->getFaction()->getUnitCount();
+		//validate unit
+		if(unit != NULL) {
+			this->unitFactionIndex = unit->getFaction()->getIndex();
+			this->unitFactionUnitCount = unit->getFaction()->getUnitCount();
 
-            //const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), this->unitTypeId);
-            const CommandType *ct   = unit->getType()->findCommandTypeById(this->commandTypeId);
-            if(ct != NULL && ct->getClass() == ccBuild) {
-            	if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] %s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
-                CardinalDir::assertDirValid(facing);
-                assert(targetId == -1);
-            }
-        }
-    }
+			const CommandType *ct= unit->getType()->findCommandTypeById(this->commandTypeId);
+			if(unitTypeId > -1) { 
+				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), this->unitTypeId);
+				ct= unitType->findCommandTypeById(this->commandTypeId);
+			}
+            
+			if(ct != NULL && ct->getClass() == ccBuild) {
+				if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] 						%s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
+				CardinalDir::assertDirValid(facing);
+				assert(targetId == -1);
+			}
+		}
+	}
 
-    if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] Created NetworkCommand as follows:\n%s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
+	if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] Created NetworkCommand as follows:\n%s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
 }
 
 void NetworkCommand::preprocessNetworkCommand(World *world) {
-    if(networkCommandType == nctGiveCommand) {
-        const Unit *unit= world->findUnitById(unitId);
+	if(networkCommandType == nctGiveCommand) {
+		const Unit *unit= world->findUnitById(unitId);
 
-        //validate unit
-        if(unit != NULL) {
-            //const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), unitTypeId);
-            const CommandType *ct   = unit->getType()->findCommandTypeById(commandTypeId);
-            if(ct != NULL && ct->getClass() == ccBuild && targetId >= 0) {
+		//validate unit
+		if(unit != NULL) {
+
+			const CommandType *ct= unit->getType()->findCommandTypeById(commandTypeId);
+			if(unitTypeId > -1) { 
+				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), unitTypeId);
+				ct= unitType->findCommandTypeById(this->commandTypeId);
+			}
+			
+			if(ct != NULL && ct->getClass() == ccBuild && targetId >= 0) {
 				CardinalDir::assertDirValid(targetId);
-            }
-        }
-        else {
-        	if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] (unit == NULL) %s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
-        }
-    }
+			}
+		}
+		else {
+			if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] (unit == NULL) %s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
+		}
+	}
 }
 
 

--- a/source/glest_game/network/network_types.cpp
+++ b/source/glest_game/network/network_types.cpp
@@ -59,7 +59,8 @@ NetworkCommand::NetworkCommand(World *world, int networkCommandType, int unitId,
 			const CommandType *ct= unit->getType()->findCommandTypeById(this->commandTypeId);
 			if(unitTypeId > -1) { 
 				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), this->unitTypeId);
-				ct= unitType->findCommandTypeById(this->commandTypeId);
+				auto mct= unitType->findCommandTypeById(this->commandTypeId);
+				if(mct) ct= mct;
 			}
             
 			if(ct != NULL && ct->getClass() == ccBuild) {
@@ -83,7 +84,8 @@ void NetworkCommand::preprocessNetworkCommand(World *world) {
 			const CommandType *ct= unit->getType()->findCommandTypeById(commandTypeId);
 			if(unitTypeId > -1) { 
 				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), unitTypeId);
-				ct= unitType->findCommandTypeById(this->commandTypeId);
+				auto mct= unitType->findCommandTypeById(this->commandTypeId);
+				if(mct) ct= mct;
 			}
 			
 			if(ct != NULL && ct->getClass() == ccBuild && targetId >= 0) {

--- a/source/glest_game/network/network_types.cpp
+++ b/source/glest_game/network/network_types.cpp
@@ -28,12 +28,13 @@ namespace Glest{ namespace Game{
 
 NetworkCommand::NetworkCommand(World *world, int networkCommandType, int unitId,
 								int commandTypeId, const Vec2i &pos, int unitTypeId,
-								int targetId, int facing, bool wantQueue,
+								int nextUnitTypeId, int targetId, int facing, bool wantQueue,
 								CommandStateType commandStateType,
 								int commandStateValue, int unitCommandGroupId)
 		: networkCommandType(networkCommandType)
 		, unitId(unitId)
 		, unitTypeId(unitTypeId)
+		, nextUnitTypeId(nextUnitTypeId)
 		, commandTypeId(commandTypeId)
 		, positionX(pos.x)
 		, positionY(pos.y)
@@ -57,11 +58,6 @@ NetworkCommand::NetworkCommand(World *world, int networkCommandType, int unitId,
 			this->unitFactionUnitCount = unit->getFaction()->getUnitCount();
 
 			const CommandType *ct= unit->getType()->findCommandTypeById(this->commandTypeId);
-			if(unitTypeId > -1) { 
-				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), this->unitTypeId);
-				auto mct= unitType->findCommandTypeById(this->commandTypeId);
-				if(mct) ct= mct;
-			}
             
 			if(ct != NULL && ct->getClass() == ccBuild) {
 				if(SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled) SystemFlags::OutputDebug(SystemFlags::debugNetwork,"In [%s::%s Line: %d] 						%s\n",__FILE__,__FUNCTION__,__LINE__,toString().c_str());
@@ -82,12 +78,7 @@ void NetworkCommand::preprocessNetworkCommand(World *world) {
 		if(unit != NULL) {
 
 			const CommandType *ct= unit->getType()->findCommandTypeById(commandTypeId);
-			if(unitTypeId > -1) { 
-				const UnitType *unitType= world->findUnitTypeById(unit->getFaction()->getType(), unitTypeId);
-				auto mct= unitType->findCommandTypeById(this->commandTypeId);
-				if(mct) ct= mct;
-			}
-			
+
 			if(ct != NULL && ct->getClass() == ccBuild && targetId >= 0) {
 				CardinalDir::assertDirValid(targetId);
 			}

--- a/source/glest_game/network/network_types.h
+++ b/source/glest_game/network/network_types.h
@@ -94,6 +94,7 @@ public:
 		networkCommandType=0;
 		unitId=0;
 		unitTypeId=0;
+		nextUnitTypeId=0;
 		commandTypeId=0;
 		positionX=0;
 		positionY=0;
@@ -114,6 +115,7 @@ public:
 		int commandTypeId= -1,
 		const Vec2i &pos= Vec2i(0),
 		int unitTypeId= -1,
+		int nextUnitTypeId= -1,
 		int targetId= -1,
 		int facing= -1,
 		bool wantQueue = false,
@@ -124,6 +126,7 @@ public:
 	int16 networkCommandType;
 	int32 unitId;
 	int16 unitTypeId;
+	int16 nextUnitTypeId;
 	int16 commandTypeId;
 	int16 positionX;
 	int16 positionY;
@@ -141,6 +144,7 @@ public:
 	int getCommandTypeId() const						{return commandTypeId;}
 	Vec2i getPosition() const							{return Vec2i(positionX, positionY);}
 	int getUnitTypeId() const							{return unitTypeId;}
+	int getNextUnitTypeId() const						{return nextUnitTypeId;}
 	int getTargetId() const								{return targetId;}
 	int getWantQueue() const							{return wantQueue;}
 	int getFromFactionIndex() const						{return fromFactionIndex;}

--- a/source/glest_game/type_instances/command.cpp
+++ b/source/glest_game/type_instances/command.cpp
@@ -76,12 +76,6 @@ Command::Command(const CommandType *ct, const Vec2i &pos, const UnitType *unitTy
 	//}
 }
 
-int Command::getPriority(){
-	if(this->commandType->commandTypeClass==ccAttack && getUnit()==NULL){
-		return 5; // attacks to the ground have low priority
-	}
-	return this->commandType->getTypePriority();
-}
 // =============== set ===============
 
 void Command::setCommandType(const CommandType *commandType) {

--- a/source/glest_game/type_instances/command.h
+++ b/source/glest_game/type_instances/command.h
@@ -71,9 +71,6 @@ public:
 	inline const UnitType* getUnitType() const			{return unitType;}
 	inline CardinalDir getFacing() const				{return facing;}
 	
-	//Priority: commands of higher priority will cancel commands of lower priority
-	virtual int getPriority();
-	
     //set 
     void setCommandType(const CommandType *commandType);
     void setPos(const Vec2i &pos);

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -747,7 +747,7 @@ void Unit::cleanupAllParticlesystems() {
 
 const MorphCommandType* Unit::getCurrMorphCt() const {
 	auto result = std::find_if(commands.rbegin(), commands.rend(),[](Command *i) 
-	{ return i->getCommandType()->getClass() == ccMorph? true: false; });
+	{ return i->getCommandType()->getClass() == ccMorph; });//TODO set CurrMorphCt on push comands instead of looping
 	if(result != commands.rend()) {
 		return static_cast<const MorphCommandType*>((*result)->getCommandType());
 	}

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -3829,13 +3829,14 @@ std::pair<CommandResult,string> Unit::checkCommand(Command *command) const {
        (ignoreCheckCommand == false && this->getFaction()->reqsOk(command->getCommandType()) == false)) {
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugLUA).enabled) SystemFlags::OutputDebug(SystemFlags::debugLUA,"In [%s::%s Line: %d] isOperative() = %d, command->getUnit() = %p, getType()->hasCommandType(command->getCommandType()) = %d, this->getFaction()->reqsOk(command->getCommandType()) = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__, __LINE__,isOperative(),command->getUnit(),getType()->hasCommandType(command->getCommandType()),this->getFaction()->reqsOk(command->getCommandType()));
 
+		auto mct = getCurrMorphCt();
 		// Allow self healing if able to heal own unit type
 		if(	command->getUnit() == this &&
 			command->getCommandType()->getClass() == ccRepair &&
 			this->getType()->getFirstRepairCommand(this->getType()) != NULL) {
 
 		}
-		else if(getCurrMorphCt()->getMorphUnit()->hasCommandType(command->getCommandType())) {
+		else if(mct && mct->getMorphUnit()->hasCommandType(command->getCommandType())) {
 			// Allow Current Morph Commands
 		}
 		else {

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -745,6 +745,15 @@ void Unit::cleanupAllParticlesystems() {
 
 }
 
+const MorphCommandType* Unit::getCurrMorphCt() const {
+	auto result = std::find_if(commands.rbegin(), commands.rend(),[](Command *i) 
+	{ return i->getCommandType()->getClass() == ccMorph? true: false; });
+	if(result != commands.rend()) {
+		return static_cast<const MorphCommandType*>((*result)->getCommandType());
+	}
+	else return NULL;
+}
+
 ParticleSystem * Unit::getFire() const	{
 	if(this->fire != NULL &&
 		Renderer::getInstance().validateParticleSystemStillExists(this->fire,rsGame) == false) {
@@ -3825,6 +3834,9 @@ std::pair<CommandResult,string> Unit::checkCommand(Command *command) const {
 			command->getCommandType()->getClass() == ccRepair &&
 			this->getType()->getFirstRepairCommand(this->getType()) != NULL) {
 
+		}
+		else if(getCurrMorphCt()->getMorphUnit()->hasCommandType(command->getCommandType())) {
+			// Allow Current Morph Commands
 		}
 		else {
 			//printf("In [%s::%s Line: %d] command = %p\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,command);

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -1828,8 +1828,6 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
     	throw megaglest_runtime_error("command->getCommandType() == NULL");
     }
 
-    const int command_priority = command->getPriority();
-
     if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 
     //printf("In [%s::%s] Line: %d unit [%d - %s] command [%s] tryQueue = %d command->getCommandType()->isQueuable(tryQueue) = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,this->getId(),this->getType()->getName().c_str(), command->getCommandType()->getName().c_str(), tryQueue,command->getCommandType()->isQueuable(tryQueue));
@@ -1839,32 +1837,6 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled) SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d] Command is Queable\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__);
 
-		if(command->getCommandType()->isQueuable() == qAlways && tryQueue){
-			// Its a produce or upgrade command called without queued key
-			// in this case we must NOT delete lower priority commands!
-			// we just queue it!
-
-		}
-		else {
-			//Delete all lower-prioirty commands
-			for(list<Command*>::iterator i= commands.begin(); i != commands.end();){
-				if((*i)->getPriority() < command_priority){
-					if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled)
-						SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d] Deleting lower priority command [%s]\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,(*i)->toString(false).c_str());
-
-					static string mutexOwnerId = string(__FILE__) + string("_") + intToStr(__LINE__);
-					MutexSafeWrapper safeMutex(mutexCommands,mutexOwnerId);
-
-					deleteQueuedCommand(*i);
-					i= commands.erase(i);
-
-					safeMutex.ReleaseLock();
-				}
-				else {
-					++i;
-				}
-			}
-		}
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,chrono.getMillis());
 
 		//cancel current command if it is not queuable

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -1857,7 +1857,7 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
 				cancelCommand();
 			}
 			else //when last cmd low-priority and current cmd high-priory without queue-key
-				if(lastCt->isQueuable() != qAlways &&
+				if(lastCt->isQueuable() == qOnRequest &&
 					command->getCommandType()->isQueuable() == qAlways && !tryQueue){
 				clearCommands();
 			}

--- a/source/glest_game/type_instances/unit.h
+++ b/source/glest_game/type_instances/unit.h
@@ -653,6 +653,7 @@ public:
 		}
 		return NULL;
 	}
+	const MorphCommandType* getCurrMorphCt() const;
 	void replaceCurrCommand(Command *cmd);
 	int getCountOfProducedUnitsPreExistence(const UnitType *ut) const;
 	unsigned int getCommandSize() const;

--- a/source/glest_game/type_instances/unit.h
+++ b/source/glest_game/type_instances/unit.h
@@ -674,7 +674,7 @@ public:
 
     //other
 	void resetHighlight();
-	const CommandType *computeCommandType(const Vec2i &pos, const Unit *targetUnit= NULL) const;
+	const CommandType *computeCommandType(const Vec2i &pos, const Unit *targetUnit= NULL, const UnitType* unitType= NULL) const;
 	string getDesc(bool translatedValue) const;
 	string getDescExtension(bool translatedValue) const;
     bool computeEp();

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -108,8 +108,6 @@ public:
 		Queueability q = isQueuable();
 		return (q != qNever) && (q != qOnlyLast);
 	}
-	//Priority: commands of higher priority will cancel commands of lower priority
-	virtual int getTypePriority() const {return 10;}
 	virtual bool usesPathfinder() const= 0;
 
     //get
@@ -139,7 +137,6 @@ public:
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
 	virtual string toString(bool translatedValue) const;
 	virtual Queueability isQueuable() const						{return qNever;}
-	virtual int getTypePriority() const							{return 100000;}
     //get
 	const StopSkillType *getStopSkillType() const	{return stopSkillType;};
 
@@ -213,6 +210,7 @@ public:
     		const TechTree *tt, const FactionType *ft, const UnitType &ut,
     		std::map<string,vector<pair<string, string> > > &loadedFileList, string parentLoader);
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
+	virtual Queueability isQueuable() const	{return qOnlyLast;}
 	virtual string toString(bool translatedValue) const;
 
     //get
@@ -369,7 +367,6 @@ public:
 	virtual string toString(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
 	virtual Queueability isQueuable() const						{return qAlways;}
-	virtual int getTypePriority() const {return 15;}
 
     //get
 	const ProduceSkillType *getProduceSkillType() const	{return produceSkillType;}
@@ -399,7 +396,6 @@ public:
 	virtual string getReqDesc(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
 	virtual Queueability isQueuable() const						{return qAlways;}
-	virtual int getTypePriority() const {return 15;}
 
     //get
 	const UpgradeSkillType *getUpgradeSkillType() const		{return upgradeSkillType;}

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -425,7 +425,7 @@ public:
 	virtual string toString(bool translatedValue) const;
 	virtual string getReqDesc(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
-	Queueability isQueuable() const						{return qOnlyLast;} //After morph anything can happen
+	Queueability isQueuable() const						{return qAlways;} //After morph anything can happen
 
     //get
 	const MorphSkillType *getMorphSkillType() const		{return morphSkillType;}

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -277,7 +277,6 @@ public:
     		std::map<string,vector<pair<string, string> > > &loadedFileList, string parentLoader);
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
 	virtual string toString(bool translatedValue) const;
-	virtual Queueability isQueuable() const						{return qOnRequest;}
 
     //get
 	const MoveSkillType *getMoveSkillType() const			{return moveSkillType;}
@@ -308,7 +307,6 @@ public:
     		std::map<string,vector<pair<string, string> > > &loadedFileList, string parentLoader);
     virtual string getDesc(const TotalUpgrade *totalUpgrade, bool translatedValue) const;
 	virtual string toString(bool translatedValue) const;
-	virtual Queueability isQueuable() const						{return qOnRequest;}
 
     //get
 	virtual bool usesPathfinder() const { return true; }
@@ -425,7 +423,6 @@ public:
 	virtual string toString(bool translatedValue) const;
 	virtual string getReqDesc(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
-	Queueability isQueuable() const						{return qOnRequest;}
 
     //get
 	const MorphSkillType *getMorphSkillType() const		{return morphSkillType;}

--- a/source/glest_game/types/command_type.h
+++ b/source/glest_game/types/command_type.h
@@ -425,7 +425,7 @@ public:
 	virtual string toString(bool translatedValue) const;
 	virtual string getReqDesc(bool translatedValue) const;
 	virtual const ProducibleType *getProduced() const;
-	Queueability isQueuable() const						{return qAlways;} //After morph anything can happen
+	Queueability isQueuable() const						{return qOnRequest;}
 
     //get
 	const MorphSkillType *getMorphSkillType() const		{return morphSkillType;}

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -720,20 +720,6 @@ void UnitUpdater::updateAttack(Unit *unit, int frameIndex) {
 
 	if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s Line: %d] took msecs: %lld\n",__FILE__,__FUNCTION__,__LINE__,chrono.getMillis());
 
-	if( (command->getUnit() == NULL || !(command->getUnit()->isAlive()) ) && unit->getCommandSize() > 1) {
-
-		if(frameIndex < 0) {
-			unit->finishCommand(); // all queued "ground attacks" are skipped if somthing else is queued after them.
-
-			if(SystemFlags::getSystemSettingType(SystemFlags::debugWorldSynch).enabled == true && frameIndex < 0) {
-				char szBuf[8096]="";
-				snprintf(szBuf,8096,"[updateAttack]");
-				unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(),__LINE__,szBuf);
-			}
-		}
-		return;
-	}
-
 	//if found
 	//if(frameIndex < 0) {
 	{

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -1320,7 +1320,7 @@ void UnitUpdater::updateHarvestEmergencyReturn(Unit *unit, int frameIndex) {
 						if(previousHarvestCmd != NULL) {
 							//printf("\n\n#1a return harvested resources\n\n");
 							NetworkCommand networkCommand(this->world,nctGiveCommand, unit->getId(), previousHarvestCmd->getId(), unit->getLastHarvestedResourcePos(),
-															-1, Unit::invalidId, -1, false, cst_None, -1, -1);
+															-1, -1, Unit::invalidId, -1, false, cst_None, -1, -1);
 
 							if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled) SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d]\n",__FILE__,__FUNCTION__,__LINE__);
 
@@ -2058,7 +2058,7 @@ void UnitUpdater::updateRepair(Unit *unit, int frameIndex) {
 
 						const CommandType *ctbuild = unit->getType()->getFirstCtOfClass(ccBuild);
 						NetworkCommand networkCommand(this->world,nctGiveCommand, unit->getId(), ctbuild->getId(), command->getPos(),
-														command->getUnitType()->getId(), -1, CardinalDir(CardinalDir::NORTH), true, command->getStateType(),
+														command->getUnitType()->getId(), -1, -1, CardinalDir(CardinalDir::NORTH), true, command->getStateType(),
 														command->getStateValue());
 
 						if(SystemFlags::getSystemSettingType(SystemFlags::debugUnitCommands).enabled) SystemFlags::OutputDebug(SystemFlags::debugUnitCommands,"In [%s::%s Line: %d]\n",__FILE__,__FUNCTION__,__LINE__);


### PR DESCRIPTION
This PR kinda improved command priority system, more intuitive, without any restrictions
- [x]  fixed #236 
- [x]  disable stop command with pressed shift 
- [x] test in few internet games
- [ ] may be refactor https://github.com/pavanvo/megaglest-source/blob/8d141ca57fc466c6bcda2e8c7ae268b22b63ae0c/source/glest_game/type_instances/unit.cpp#L748 , but now I think it works pretty fast
- [ ] fix bug what allowed to press, morph unit cmd quickly after morph was aborted, for instance: when position is invalid

