### PR TITLE
Add Version to Uninstall Info

### DIFF
--- a/mk/windoze/Installer/MegaGlestInstaller.nsi
+++ b/mk/windoze/Installer/MegaGlestInstaller.nsi
@@ -283,6 +283,7 @@ Section "${APNAME} (required)"
 
   ; Write the uninstall keys for Windows
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APNAME}" "DisplayName" "${APNAME} v${APVER}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APNAME}" "DisplayVersion" "${APVER}"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APNAME}" "UninstallString" '"$INSTDIR\uninstall.exe"'
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APNAME}" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APNAME}" "NoRepair" 1


### PR DESCRIPTION
This change causes the version to be written to the control panel's "Version" field. This enables package managers like [WinGet](/microsoft/winget-cli) and other software to understand the actual version that is installed rather than reporting it as "Unknown"