### PR TITLE
Add many missing cstring includes (fix build with GCC 15)

### DIFF
--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -11,6 +11,8 @@
 
 #include "core_data.h"
 
+#include <cstring>
+
 #include "logger.h"
 #include "renderer.h"
 #include "graphics_interface.h"

--- a/source/glest_game/network/network_types.h
+++ b/source/glest_game/network/network_types.h
@@ -18,6 +18,7 @@
 #endif
 
 #include <string>
+#include <cstring>
 #include "data_types.h"
 #include "vec.h"
 #include "command.h"

--- a/source/shared_lib/include/platform/sdl/window.h
+++ b/source/shared_lib/include/platform/sdl/window.h
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <string>
+#include <cstring>
 #include <SDL.h>
 #include <cassert>
 #include "data_types.h"

--- a/source/shared_lib/sources/graphics/JPGReader.cpp
+++ b/source/shared_lib/sources/graphics/JPGReader.cpp
@@ -14,6 +14,7 @@
 
 #include "data_types.h"
 #include "pixmap.h"
+#include <cstring>
 #include <stdexcept>
 #include <jpeglib.h>
 #include <setjmp.h>

--- a/source/shared_lib/sources/graphics/PNGReader.cpp
+++ b/source/shared_lib/sources/graphics/PNGReader.cpp
@@ -13,6 +13,7 @@
 
 #include "data_types.h"
 #include "pixmap.h"
+#include <cstring>
 #include <stdexcept>
 #include <png.h>
 #include <setjmp.h>

--- a/source/shared_lib/sources/graphics/gl/opengl.cpp
+++ b/source/shared_lib/sources/graphics/gl/opengl.cpp
@@ -12,6 +12,7 @@
 #include "opengl.h"
 
 #include <stdexcept>
+#include <cstring>
 
 #include "graphics_interface.h"
 #include "context_gl.h"

--- a/source/shared_lib/sources/graphics/model.cpp
+++ b/source/shared_lib/sources/graphics/model.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cassert>
 #include <stdexcept>
+#include <cstring>
 
 #include "interpolation.h"
 #include "conversion.h"

--- a/source/shared_lib/sources/graphics/pixmap.cpp
+++ b/source/shared_lib/sources/graphics/pixmap.cpp
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include <cstdio>
 #include <cassert>
+#include <cstring>
 
 #include "util.h"
 #include "math_util.h"

--- a/source/shared_lib/sources/graphics/texture.cpp
+++ b/source/shared_lib/sources/graphics/texture.cpp
@@ -15,6 +15,8 @@
 #include "platform_util.h"
 #include "leak_dumper.h"
 
+#include <cstring>
+
 using namespace Shared::Util;
 using namespace Shared::Platform;
 

--- a/source/shared_lib/sources/map/map_preview.cpp
+++ b/source/shared_lib/sources/map/map_preview.cpp
@@ -14,6 +14,7 @@
 
 #include "math_wrapper.h"
 #include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <set>
 #include <iterator>

--- a/source/shared_lib/sources/sound/sound_file_loader.cpp
+++ b/source/shared_lib/sources/sound/sound_file_loader.cpp
@@ -11,6 +11,8 @@
 
 #include "sound_file_loader.h"
 
+#include <cstring>
+
 #include <vorbis/codec.h>
 #include <vorbis/vorbisfile.h>
 

--- a/source/shared_lib/sources/util/conversion.cpp
+++ b/source/shared_lib/sources/util/conversion.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include "platform_common.h"
 #include <sstream>
 #include <iostream>

--- a/source/shared_lib/sources/util/string_utils.cpp
+++ b/source/shared_lib/sources/util/string_utils.cpp
@@ -19,6 +19,7 @@
 #include "string_utils.h"
 
 #include <algorithm>
+#include <cstring>
 #include <assert.h>
 
 namespace Shared { namespace Util {


### PR DESCRIPTION
megaglest failed to build on Fedora Rawhide with GCC 15 because a bunch of files use C string functions without including cstring. This fixes all of them, or at least all the ones we hit during the Fedora build.