### PR TITLE
setupBuildDeps.sh: Replace lua with lua53 on Manjaro

### DIFF
--- a/mk/linux/setupBuildDeps.sh
+++ b/mk/linux/setupBuildDeps.sh
@@ -276,7 +276,7 @@ ManjaroLinux* | Manjarolinux*)
 	if [ "$architecture" = "x86_64" ] || [ "$architecture" = "aarch64" ]; then lib=""; else lib="lib32-"; fi
 	case $release in
 	*)
-		installcommand="pacman $PACMAN_OPTIONS -S --needed gcc-multilib cmake ${lib}libcurl-gnutls ${lib}sdl2 ${lib}openal lua ${lib}libjpeg-turbo ${lib}libpng ${lib}freetype2 wxwidgets-gtk3 cppunit fribidi ftgl ${lib}glew ${lib}libogg ${lib}libvorbis miniupnpc libircclient vlc ${lib}libxml2 ${lib}libx11 ${lib}mesa ${lib}glu"
+		installcommand="pacman $PACMAN_OPTIONS -S --needed gcc-multilib cmake ${lib}libcurl-gnutls ${lib}sdl2 ${lib}openal lua53 ${lib}libjpeg-turbo ${lib}libpng ${lib}freetype2 wxwidgets-gtk3 cppunit fribidi ftgl ${lib}glew ${lib}libogg ${lib}libvorbis miniupnpc libircclient vlc ${lib}libxml2 ${lib}libx11 ${lib}mesa ${lib}glu"
 		# unsupported_currently_this_OS="release"
 		;;
 	esac


### PR DESCRIPTION
Build was failing using gcc and clang. What fixed this for me was installing lua53 on Manjaro. I had lua51 installed.

![image](https://github.com/user-attachments/assets/e99c9181-5a58-42ab-9933-66ef142740cd)
