### PR TITLE
Fix curl deprecation warning (CURLOPT_PROGRESSFUNCTION)

### DIFF
--- a/source/shared_lib/sources/platform/posix/miniftpclient.cpp
+++ b/source/shared_lib/sources/platform/posix/miniftpclient.cpp
@@ -1002,7 +1002,7 @@ pair<FTP_Client_ResultType,string>  FTPClientThread::getFileFromServer(FTP_Clien
         	curl_easy_setopt(curl, CURLOPT_DIRLISTONLY, 1);
         }
         curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-        curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, file_progress);
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, file_progress);
         curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &ftpfile);
 
         // Max 10 minutes to transfer


### PR DESCRIPTION
Fixes warning:

```
/workspace/source/shared_lib/sources/platform/posix/miniftpclient.cpp:1005:32: warning: 'CURLOPT_PROGRESSFUNCTION' is deprecated: since 7.32.0. Use CURLOPT_XFERINFOFUNCTION [-Wdeprecated-declarations]
 1005 |         curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, file_progress);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/curl/curl.h:1291:3: note: declared here
 1291 |   CURLOPTDEPRECATED(CURLOPT_PROGRESSFUNCTION, CURLOPTTYPE_FUNCTIONPOINT, 56,
```