### PR TITLE
CI: Remove check on Ubuntu 20.04 (focal)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64]
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         compiler: [gcc, clang]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
This could be removed now. Agreed? Standard support nearing end: https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare