### PR TITLE
Allow binding to specific IP address

### DIFF
--- a/source/glest_game/main/main.cpp
+++ b/source/glest_game/main/main.cpp
@@ -5499,6 +5499,29 @@ int glestMain(int argc, char **argv) {
       }
     }
 
+    else if (hasCommandArgument(
+                 argc, argv, GAME_ARGS[GAME_ARG_SERVER_BIND_ADDRESS]) == true) {
+      int foundParamIndIndex = -1;
+      hasCommandArgument(
+          argc, argv,
+          string(GAME_ARGS[GAME_ARG_SERVER_BIND_ADDRESS]) + string("="),
+          &foundParamIndIndex);
+      if (foundParamIndIndex < 0) {
+        hasCommandArgument(argc, argv,
+                           string(GAME_ARGS[GAME_ARG_SERVER_BIND_ADDRESS]),
+                           &foundParamIndIndex);
+      }
+      string paramValue = argv[foundParamIndIndex];
+      vector<string> paramPartTokens;
+      Tokenize(paramValue, paramPartTokens, "=");
+      if (paramPartTokens.size() >= 2 && paramPartTokens[1].length() > 0) {
+        string itemName = paramPartTokens[1];
+
+        Config &config = Config::getInstance();
+        config.setString("ServerBindAddress", itemName);
+      }
+    }
+
     if (hasCommandArgument(argc, argv,
                            string(GAME_ARGS[GAME_ARG_MASTERSERVER_STATUS])) ==
         true) {

--- a/source/glest_game/menu/menu_state_options_network.cpp
+++ b/source/glest_game/menu/menu_state_options_network.cpp
@@ -52,6 +52,8 @@ MenuStateOptionsNetwork::MenuStateOptionsNetwork(Program *program,
       mainMessageBox("Options_Network", "mainMessageBox"),
 
       labelExternalPort("Options_Network", "labelExternalPort"),
+      labelServerBindIpLabel("Options_Network", "labelServerBindIpLabel"),
+      labelServerBindIpTextInput("Options_Network", "labelServerBindIpTextInput"),
       labelServerPortLabel("Options_Network", "labelServerPortLabel"),
 
       labelPublishServerExternalPort("Options_Network",
@@ -91,6 +93,7 @@ MenuStateOptionsNetwork::MenuStateOptionsNetwork(Program *program,
     Config &config = Config::getInstance();
     this->parentUI = parentUI;
     this->console.setOnlyChatMessagesInStoredLines(false);
+    this->activeInputLabel = NULL;
 
     int leftLabelStart = 100;
     int leftColumnStart = leftLabelStart + 300;
@@ -152,8 +155,21 @@ MenuStateOptionsNetwork::MenuStateOptionsNetwork(Program *program,
       extPort = "!!! " + extPort + " !!!";
     }
     labelExternalPort.setText(extPort);
-
     currentLine -= lineOffset;
+
+    // Server bind IP
+    labelServerBindIpLabel.init(currentLabelStart, currentLine);
+    labelServerBindIpLabel.setText(lang.getString("ServerBindIP"));
+
+    labelServerBindIpTextInput.init(currentColumnStart, currentLine);
+    labelServerBindIpTextInput.setText(config.getString("ServerBindAddress", ""));
+    labelServerBindIpTextInput.setFont(CoreData::getInstance().getMenuFontBig());
+    labelServerBindIpTextInput.setFont3D(CoreData::getInstance().getMenuFontBig3D());
+    labelServerBindIpTextInput.setEditable(true);
+    labelServerBindIpTextInput.setMaxEditWidth(16);
+    labelServerBindIpTextInput.setMaxEditRenderWidth(200);
+    currentLine -= lineOffset;
+
     // server port
     labelServerPortLabel.init(currentLabelStart, currentLine);
     labelServerPortLabel.setText(lang.getString("ServerPort"));
@@ -292,6 +308,7 @@ void MenuStateOptionsNetwork::reloadUI() {
   }
 
   labelServerPortLabel.setText(lang.getString("ServerPort"));
+  labelServerBindIpLabel.setText(lang.getString("ServerBindAddress"));
   labelPublishServerExternalPort.setText(
       lang.getString("PublishServerExternalPort"));
   labelEnableFTP.setText(lang.getString("EnableFTP"));
@@ -347,6 +364,9 @@ void MenuStateOptionsNetwork::mouseClick(int x, int y,
     }
     mainMenu->setState(new MenuStateRoot(program, mainMenu));
     return;
+  } else if (labelServerBindIpTextInput.mouseClick(x, y) &&
+             (activeInputLabel != &labelServerBindIpTextInput)) {
+    this->setActiveInputLabel(&labelServerBindIpTextInput);
   } else if (buttonAudioSection.mouseClick(x, y)) {
     soundRenderer.playFx(coreData.getClickSoundA());
     mainMenu->setState(new MenuStateOptionsSound(
@@ -422,35 +442,29 @@ void MenuStateOptionsNetwork::mouseMove(int x, int y, const MouseState *ms) {
 }
 
 // bool MenuStateOptionsNetwork::isInSpecialKeyCaptureEvent() {
-//	return (activeInputLabel != NULL);
-// }
-//
-// void MenuStateOptionsNetwork::keyDown(SDL_KeyboardEvent key) {
-//	if(activeInputLabel != NULL) {
-//		keyDownEditLabel(key, &activeInputLabel);
-//	}
-// }
+// return (activeInputLabel != NULL);
+//}
+
+void MenuStateOptionsNetwork::keyDown(SDL_KeyboardEvent key) {
+  if (activeInputLabel != NULL) {
+    keyDownEditLabel(key, &activeInputLabel);
+  }
+}
 
 void MenuStateOptionsNetwork::keyPress(SDL_KeyboardEvent c) {
-  //	if(activeInputLabel != NULL) {
-  //	    //printf("[%d]\n",c); fflush(stdout);
-  //		if( &labelPlayerName 	== activeInputLabel ||
-  //			&labelTransifexUser == activeInputLabel ||
-  //			&labelTransifexPwd == activeInputLabel ||
-  //			&labelTransifexI18N == activeInputLabel) {
-  //			textInputEditLabel(c, &activeInputLabel);
-  //		}
-  //	}
-  //	else {
-  Config &configKeys = Config::getInstance(
-      std::pair<ConfigType, ConfigType>(cfgMainKeys, cfgUserKeys));
-  if (isKeyPressed(configKeys.getSDLKey("SaveGUILayout"), c) == true) {
-    GraphicComponent::saveAllCustomProperties(containerName);
-    // Lang &lang= Lang::getInstance();
-    // console.addLine(lang.getString("GUILayoutSaved") + " [" + (saved ?
-    // lang.getString("Yes") : lang.getString("No"))+ "]");
+  if (activeInputLabel != NULL) {
+    keyPressEditLabel(c, &activeInputLabel);
+  } else {
+    Config &configKeys = Config::getInstance(
+        std::pair<ConfigType, ConfigType>(cfgMainKeys, cfgUserKeys));
+    if (isKeyPressed(configKeys.getSDLKey("SaveGUILayout"), c) == true) {
+      GraphicComponent::saveAllCustomProperties(containerName);
+      // Lang &lang= Lang::getInstance();
+      // console.addLine(lang.getString("GUILayoutSaved") + " [" + (saved ?
+      // lang.getString("Yes") : lang.getString("No"))+ "]");
+    }
+    //	}
   }
-  //	}
 }
 
 void MenuStateOptionsNetwork::render() {
@@ -467,6 +481,8 @@ void MenuStateOptionsNetwork::render() {
     renderer.renderButton(&buttonMiscSection);
     renderer.renderButton(&buttonNetworkSettings);
     renderer.renderLabel(&labelServerPortLabel);
+    renderer.renderLabel(&labelServerBindIpLabel);
+    renderer.renderLabel(&labelServerBindIpTextInput);
     renderer.renderLabel(&labelExternalPort);
     renderer.renderLabel(&labelPublishServerExternalPort);
     renderer.renderListBox(&listBoxServerPort);
@@ -498,10 +514,11 @@ void MenuStateOptionsNetwork::render() {
 void MenuStateOptionsNetwork::saveConfig() {
   Config &config = Config::getInstance();
   Lang &lang = Lang::getInstance();
-  setActiveInputLable(NULL);
+  this->setActiveInputLabel(NULL);
 
   lang.loadGameStrings(config.getString("Lang"));
 
+  config.setString("ServerBindAddress", labelServerBindIpTextInput.getText());
   config.setString("PortServer", listBoxServerPort.getSelectedItem());
   config.setInt("FTPServerPort", config.getInt("PortServer") + 1);
   config.setBool("EnableFTPXfer", checkBoxEnableFTP.getValue());
@@ -520,7 +537,18 @@ void MenuStateOptionsNetwork::saveConfig() {
   console.addLine(lang.getString("SettingsSaved"));
 }
 
-void MenuStateOptionsNetwork::setActiveInputLable(GraphicLabel *newLable) {}
+bool MenuStateOptionsNetwork::textInput(std::string text) {
+  if (activeInputLabel != NULL) {
+    if (&labelServerBindIpTextInput == activeInputLabel) {
+      return textInputEditLabel(text, &activeInputLabel);
+    }
+  }
+  return false;
+}
+
+void MenuStateOptionsNetwork::setActiveInputLabel(GraphicLabel *newLabel) {
+  MenuState::setActiveInputLabel(newLabel, &activeInputLabel);
+}
 
 }  // namespace Game
 }  // namespace Glest

--- a/source/glest_game/menu/menu_state_options_network.h
+++ b/source/glest_game/menu/menu_state_options_network.h
@@ -37,7 +37,10 @@ class MenuStateOptionsNetwork : public MenuState {
   int mainMessageBoxState;
 
   GraphicLabel labelExternalPort;
+  GraphicLabel labelServerBindIpTextInput;
+  GraphicLabel labelServerBindIpLabel;
   GraphicLabel labelServerPortLabel;
+  GraphicLabel *activeInputLabel;
 
   GraphicLabel labelPublishServerExternalPort;
   GraphicListBox listBoxServerPort;
@@ -73,15 +76,16 @@ class MenuStateOptionsNetwork : public MenuState {
   void mouseDoubleClick(int x, int y, MouseButton mouseButton) {};
   void mouseMove(int x, int y, const MouseState *mouseState);
   void render();
-  // virtual void keyDown(SDL_KeyboardEvent key);
+  virtual bool textInput(std::string text);
+  virtual void keyDown(SDL_KeyboardEvent key);
   virtual void keyPress(SDL_KeyboardEvent c);
-  // virtual bool isInSpecialKeyCaptureEvent();
+  //  virtual bool isInSpecialKeyCaptureEvent();
 
   virtual void reloadUI();
 
  private:
   void saveConfig();
-  void setActiveInputLable(GraphicLabel *newLable);
+  void setActiveInputLabel(GraphicLabel *newLabel);
   // void showMessageBox(const string &text, const string &header, bool toggle);
 };
 

--- a/source/glest_game/network/server_interface.cpp
+++ b/source/glest_game/network/server_interface.cpp
@@ -158,6 +158,8 @@ ServerInterface::ServerInterface(
         extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__);
 
   serverSocket.setBlock(false);
+  serverSocket.setBindAddress(
+      Config::getInstance().getString("ServerBindAddress", ""));
   serverSocket.setBindPort(Config::getInstance().getInt(
       "PortServer", intToStr(GameConstants::serverPort).c_str()));
 

--- a/source/shared_lib/include/platform/posix/socket.h
+++ b/source/shared_lib/include/platform/posix/socket.h
@@ -281,6 +281,7 @@ class ServerSocket : public Socket, public UPNPInitInterface {
   bool portBound;
   int boundPort;
   string bindSpecificAddress;
+  string bindAddress;
 
   static int externalPort;
   static int ftpServerPort;
@@ -311,6 +312,7 @@ class ServerSocket : public Socket, public UPNPInitInterface {
   void clearBlockedIPAddress();
   bool hasBlockedIPAddresses() const;
 
+  void setBindAddress(string address) { bindAddress = address; }
   void setBindPort(int port) { boundPort = port; }
   int getBindPort() const { return boundPort; }
   bool isPortBound() const { return portBound; }

--- a/source/shared_lib/include/platform/sdl/platform_main.h
+++ b/source/shared_lib/include/platform/sdl/platform_main.h
@@ -34,7 +34,7 @@ const char *GAME_ARGS[] = {"--help",
                            "--headless-server-status",
                            "--server-title",
                            "--use-ports",
-
+                           "--bind-address",
                            "--load-scenario",
                            "--load-mod",
                            "--preview-map",
@@ -100,10 +100,7 @@ const char *GAME_ARGS[] = {"--help",
                            "--steam",
                            "--steam-debug",
                            "--steam-reset-stats",
-
-                           "--verbose"
-
-};
+                           "--verbose"};
 
 enum GAME_ARG_TYPE {
   GAME_ARG_HELP = 0,
@@ -118,7 +115,7 @@ enum GAME_ARG_TYPE {
   GAME_ARG_MASTERSERVER_STATUS,
   GAME_ARG_SERVER_TITLE,
   GAME_ARG_USE_PORTS,
-
+  GAME_ARG_SERVER_BIND_ADDRESS,
   GAME_ARG_LOADSCENARIO,
   GAME_ARG_MOD,
   GAME_ARG_PREVIEW_MAP,
@@ -256,7 +253,8 @@ void printParameterHelp(const char *argv0, bool foundInvalidArgs) {
       "LAN host you may");
   printf("\n\n                     \t    use: %s=auto-connect",
          GAME_ARGS[GAME_ARG_CONNECT]);
-
+  printf("\n\n%s=x  \tBind game server to a specific IP address.\n",
+         GAME_ARGS[GAME_ARG_SERVER_BIND_ADDRESS]);
   printf("\n\n%s=x  \tAuto connect to host server at IP or hostname x.",
          GAME_ARGS[GAME_ARG_CLIENT]);
   printf(
@@ -732,7 +730,6 @@ void printParameterHelp(const char *argv0, bool foundInvalidArgs) {
 
   printf("\n\n%s=x=y  ", GAME_ARGS[GAME_ARG_STEAM]);
   printf("\n\n                     \tRun with Steam Client Integration.");
-
   printf("\n\n%s  \t\tDisplays verbose information in the console.",
          GAME_ARGS[GAME_ARG_VERBOSE_MODE]);
   printf("\n\n");

--- a/source/shared_lib/sources/platform/posix/socket.cpp
+++ b/source/shared_lib/sources/platform/posix/socket.cpp
@@ -3100,13 +3100,30 @@ void ServerSocket::bind(int port) {
   }
 
   // sockaddr structure
-  sockaddr_in addr;
+  sockaddr_in addr = {};
   addr.sin_family = AF_INET;
   if (this->bindSpecificAddress != "") {
     addr.sin_addr.s_addr = inet_addr(this->bindSpecificAddress.c_str());
   } else {
-    addr.sin_addr.s_addr = INADDR_ANY;
+    if (this->bindAddress.empty()) {
+      addr.sin_addr.s_addr = INADDR_ANY;
+    } else {
+      int res = inet_pton(AF_INET, this->bindAddress.c_str(), &addr.sin_addr);
+
+      if (res <= 0) {
+        std::string stdBuf;
+        if (res == 0) {
+          stdBuf = this->bindAddress + ": Invalid network address\n";
+        } else {
+          // inet_pton() may return 0 or -1 on error, however, errno
+          // is not set unless -1 is returned.
+          stdBuf = "inet_pton: " + std::string(strerror(errno)) + "\n";
+        }
+        throwException(stdBuf.c_str());
+      }
+    }
   }
+
   addr.sin_port = htons(port);
   addr.sin_zero[0] = 0;
 
@@ -3122,9 +3139,9 @@ void ServerSocket::bind(int port) {
 
   int err = ::bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
   if (err < 0) {
-    char szBuf[8096] = "";
+    char szBuf[BUFSIZ] = {};
     snprintf(
-        szBuf, 8096,
+        szBuf, sizeof szBuf,
         "In [%s::%s] Error binding socket sock = " PLATFORM_SOCKET_FORMAT_TYPE
         ", address [%s] port = %d err = %d, error = %s opt_result = %d\n",
         __FILE__, __FUNCTION__, sock, this->bindSpecificAddress.c_str(), port,
@@ -3132,7 +3149,7 @@ void ServerSocket::bind(int port) {
     if (SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled)
       SystemFlags::OutputDebug(SystemFlags::debugNetwork, "%s", szBuf);
 
-    snprintf(szBuf, 8096,
+    snprintf(szBuf, sizeof szBuf,
              "Error binding socket sock = " PLATFORM_SOCKET_FORMAT_TYPE
              ", address [%s] port = %d err = %d, error = %s\n",
              sock, this->bindSpecificAddress.c_str(), port, err,


### PR DESCRIPTION
closes #264

@tomreyn This makes binding configurable via a command line option or from glestuser.ini by adding

`ServerBindAddress=....`

manually or through the Network options screen.

I've only tested this using my LAN IP.