### PR TITLE
maint: Remove "GIT_STAMP", use include for revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,48 +338,6 @@ size_t stack_depth = backtrace(stack_addrs, max_depth);
         SET(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "${CMAKE_EXE_LINKER_FLAGS_MINSIZEREL} -pthread")
     ENDIF()
 
-	# Get the git revision info for the binary
-	SET(HAS_GIT "FALSE")
-	SET(GIT_LIVE_REV_CMD "")
-
-	OPTION(WANT_GIT_STAMP "use git revision stamp" ON)
-	IF(WANT_GIT_STAMP)
-		# The stuff below gets GIT Global Revision # but ONLY when calling cmake!
-		# the FindGit.cmake module is part of the standard distribution
-		include(FindGit)
-
-		IF(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/")
-            SET(HAS_GIT "TRUE")
-            MESSAGE(STATUS "Found GIT and using GIT version stamping...")
-
-            # Get the current commit SHA1
-            execute_process(
-              COMMAND git log -1 --format=%h --abbrev=7
-              WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-              OUTPUT_VARIABLE GIT_SHA1
-              OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-
-            # Get the current version counter
-            execute_process(
-              COMMAND git rev-list HEAD --count
-              WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-              OUTPUT_VARIABLE GIT_COMMIT_COUNT
-              OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-
-            SET(GIT_LIVE_REV_CMD "`cd '${PROJECT_SOURCE_DIR}' && git rev-list HEAD --count`.`cd '${PROJECT_SOURCE_DIR}' && git log -1 --format=%h --abbrev=7`")
-
-            MESSAGE(STATUS "Using GIT revision stamp: [${GIT_COMMIT_COUNT}.${GIT_SHA1}] CMD [${GIT_LIVE_REV_CMD}]")
-
-			IF(CMAKE_GENERATOR STREQUAL Xcode)
-				SET(GIT_VERSION_CMD "-DGITVERSION='\\\\'${GIT_COMMIT_COUNT}.${GIT_SHA1}\\\\''")
-			ELSE()
-				SET(GIT_VERSION_CMD "-DGITVERSION='\\\"${GIT_LIVE_REV_CMD}\\\"'")
-			ENDIF()
-		ENDIF()
-	ENDIF()
-
 	SET(COMMON_INFO_ABOUT_PATH "(if the path is relative then is appended to the CMAKE_INSTALL_PREFIX)")
 	IF(CMAKE_INSTALL_PREFIX STREQUAL "")
 		MESSAGE(STATUS "*NOTE: NOT USING a Custom Data Install Path...")
@@ -434,9 +392,6 @@ size_t stack_depth = backtrace(stack_addrs, max_depth);
 	ENDIF()
 
 	string(TOUPPER "${CMAKE_BUILD_TYPE}" MG_BUILD_TYPE)
-	IF(HAS_GIT STREQUAL "TRUE")
-		SET(CMAKE_CXX_FLAGS_${MG_BUILD_TYPE} "${CMAKE_CXX_FLAGS_${MG_BUILD_TYPE}} ${GIT_VERSION_CMD}")
-	ENDIF()
 	SET(CMAKE_CXX_FLAGS_${MG_BUILD_TYPE} "${CMAKE_CXX_FLAGS_${MG_BUILD_TYPE}} ${CUSTOM_INSTALL_PATHS_VALUES}")
 
 	# We do some funky character escaping to get the right stuff written out to

--- a/source/glest_game/CMakeLists.txt
+++ b/source/glest_game/CMakeLists.txt
@@ -181,6 +181,32 @@ ENDIF()
 
 INCLUDE_DIRECTORIES( ${GLEST_LIB_INCLUDE_DIRS} )
 
+set(GITVERSION_H_DIR "${CMAKE_CURRENT_BINARY_DIR}/facilities")
+find_package(Git)
+IF(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/")
+	add_compile_definitions(HAVE_GIT)
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} log -1 --format=%h --abbrev=7
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		RESULT_VARIABLE GIT_RESULT
+		OUTPUT_VARIABLE GIT_REVISION
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	configure_file(
+		${CMAKE_CURRENT_SOURCE_DIR}/facilities/gitversion.h.in
+		${GITVERSION_H_DIR}/gitversion.h
+		@ONLY
+	)
+	include_directories(${GITVERSION_H_DIR})
+	# If Git command fails, set a default value
+	if(NOT GIT_RESULT EQUAL 0)
+			set(GIT_REVISION "unknown")
+	endif()
+else()
+	set(GIT_REVISION "unknown")
+endif()
+message(STATUS "Git Revision: ${GIT_REVISION}")
+
 #INCLUDE_DIRECTORIES( ${GLEST_LIB_INCLUDE_ROOT}platform/${SDL_VERSION_SNAME} )
 
 IF(WIN32)
@@ -216,13 +242,6 @@ FOREACH(DIR IN LISTS DIRS_WITH_SRC)
 		SET(MG_SOURCE_FILES ${MG_SOURCE_FILES} ${SRC_FILES_FROM_THIS_DIR})
 	ENDIF(APPLE)
 ENDFOREACH(DIR)
-
-# Force the git revision stamp (${GIT_COMMIT_COUNT}.${GIT_SHA1}) file to be touched so the compile stamp is always right
-IF(UNIX AND GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/")
-	add_custom_command(OUTPUT mg.tmp
-		COMMAND touch ${PROJECT_SOURCE_DIR}/source/glest_game/facilities/game_util.cpp)
-	add_custom_target(run ALL DEPENDS mg.tmp)
-ENDIF()
 
 IF(WIN32 AND NOT MSVC)
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-subsystem,console -mconsole")

--- a/source/glest_game/facilities/game_util.cpp
+++ b/source/glest_game/facilities/game_util.cpp
@@ -36,11 +36,11 @@ const char *mailString = " http://bugs.megaglest.org";
 const string glestVersionString = "v3.13-dev";
 const string lastCompatibleSaveGameVersionString = "v3.11.1";
 
-#if defined(GITVERSIONHEADER)
+#if defined(HAVE_GIT)
 #include "gitversion.h"
 #endif
-#if defined(GITVERSION) || defined(GITVERSIONHEADER)
-const string GIT_RawRev = string(GITVERSION);
+#if defined(GIT_REVISION) || defined(GITVERSIONHEADER)
+const string GIT_RawRev = string(GIT_REVISION);
 #else
 const string GIT_RawRev = "$5608.a3c8464$";
 #endif

--- a/source/glest_game/facilities/gitversion.h.in
+++ b/source/glest_game/facilities/gitversion.h.in
@@ -1,0 +1,6 @@
+#ifndef _GIT_REVISION_H
+#define _GIT_REVISION_H
+
+#define GIT_REVISION "@GIT_REVISION@"
+
+#endif


### PR DESCRIPTION
This is a more efficient way of stamping the git revision.

With the current behavior, this flag is getting added to almost every object in the build:

`-DGITVERSION="\"`cd "/home/andy/src/megaglest-source" && git rev-list HEAD --count`.`cd "/home/andy/src/megaglest-source" && git log -1 --format=%h --abbrev=7`\""`

This PR eliminates that.