### PR TITLE
cmake: Add revision count (removed in 52cf48959)

### DIFF
--- a/source/glest_game/CMakeLists.txt
+++ b/source/glest_game/CMakeLists.txt
@@ -184,28 +184,35 @@ INCLUDE_DIRECTORIES( ${GLEST_LIB_INCLUDE_DIRS} )
 set(GITVERSION_H_DIR "${CMAKE_CURRENT_BINARY_DIR}/facilities")
 find_package(Git)
 IF(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/")
-	add_compile_definitions(HAVE_GIT)
+	set(GIT_REVISION "unknown")
 	execute_process(
-		COMMAND ${GIT_EXECUTABLE} log -1 --format=%h --abbrev=7
+		COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		RESULT_VARIABLE GIT_RESULT
-		OUTPUT_VARIABLE GIT_REVISION
+		OUTPUT_VARIABLE GIT_REVISION_COUNT
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 	)
-	configure_file(
-		${CMAKE_CURRENT_SOURCE_DIR}/facilities/gitversion.h.in
-		${GITVERSION_H_DIR}/gitversion.h
-		@ONLY
-	)
-	include_directories(${GITVERSION_H_DIR})
-	# If Git command fails, set a default value
-	if(NOT GIT_RESULT EQUAL 0)
-			set(GIT_REVISION "unknown")
+	if(GIT_RESULT EQUAL 0)
+		execute_process(
+			COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			RESULT_VARIABLE GIT_RESULT
+			OUTPUT_VARIABLE GIT_REVISION_HASH
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+		if(GIT_RESULT EQUAL 0)
+			set(GIT_REVISION ${GIT_REVISION_COUNT}.${GIT_REVISION_HASH})
+		endif()
 	endif()
-else()
-	set(GIT_REVISION "unknown")
+	message(STATUS "Git Revision: ${GIT_REVISION}")
 endif()
-message(STATUS "Git Revision: ${GIT_REVISION}")
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/facilities/gitversion.h.in
+	${GITVERSION_H_DIR}/gitversion.h
+	@ONLY
+)
+include_directories(${GITVERSION_H_DIR})
 
 #INCLUDE_DIRECTORIES( ${GLEST_LIB_INCLUDE_ROOT}platform/${SDL_VERSION_SNAME} )
 

--- a/source/glest_game/facilities/game_util.cpp
+++ b/source/glest_game/facilities/game_util.cpp
@@ -36,9 +36,7 @@ const char *mailString = " http://bugs.megaglest.org";
 const string glestVersionString = "v3.13-dev";
 const string lastCompatibleSaveGameVersionString = "v3.11.1";
 
-#if defined(HAVE_GIT)
 #include "gitversion.h"
-#endif
 #if defined(GIT_REVISION) || defined(GITVERSIONHEADER)
 const string GIT_RawRev = string(GIT_REVISION);
 #else

--- a/source/glest_game/facilities/gitversion.h.in
+++ b/source/glest_game/facilities/gitversion.h.in
@@ -1,6 +1,6 @@
 #ifndef _GIT_REVISION_H
 #define _GIT_REVISION_H
 
-#define GIT_REVISION "@GIT_REVISION@"
+#cmakedefine GIT_REVISION "@GIT_REVISION@"
 
 #endif


### PR DESCRIPTION
Besides adding back the rev count, I've removed the compile-time macro "HAVE_GIT"