### PR TITLE
steam: Fix float stat truncation, outdated macOS SDK path, and VS det…

### DIFF
--- a/source/glest_game/steamshim/steamshim_child.c
+++ b/source/glest_game/steamshim/steamshim_child.c
@@ -268,7 +268,7 @@ static const STEAMSHIM_Event *processEvent(const uint8 *buf, size_t buflen) {
     case SHIMEVENT_SETSTATF:
     case SHIMEVENT_GETSTATF:
         event.okay = *(buf++) ? 1 : 0;
-        event.fvalue = (int)*((float *)buf);
+        event.fvalue = *((float *)buf);
         buf += sizeof(float);
         strcpy(event.name, (const char *)buf);
         break;

--- a/source/steamshim_parent/Makefile
+++ b/source/steamshim_parent/Makefile
@@ -18,7 +18,7 @@ else ifeq ($(HOST),linux32)
 else ifeq ($(HOST),linux64)
 	FLAGS		+= -L$(STEAMWORKS)/redistributable_bin/linux64 -m64
 else ifeq ($(HOST),osx)
-	FLAGS		+= -L$(STEAMWORKS)/redistributable_bin/osx32
+	FLAGS		+= -L$(STEAMWORKS)/redistributable_bin/osx
 endif
 
 FLAGS			+= -lsteam_api

--- a/source/steamshim_parent/build.bat
+++ b/source/steamshim_parent/build.bat
@@ -14,9 +14,9 @@ cd /d "%~dp0"
 ECHO using msbuild config [%MSBUILD_CONFIG%]
 ECHO Checking for windows binary runtime tools...
 
-rem setup the Visual Studio 2015 environment
+rem setup the Visual Studio environment (2022, 2019, 2017, or 2015)
 ECHO --------------------------------
-ECHO Setting up Visual Studio 2015 environment vars...
+ECHO Setting up Visual Studio environment vars...
 REM Ensure ultifds HP doesn't mess the build up
 SET Platform=
 if "%DevEnvDir%." == "." goto SETVCVARS
@@ -24,6 +24,21 @@ GOTO GITSECTION
 
 :SETVCVARS
 
+rem Try vswhere.exe to locate VS2017+ installations
+SET VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+IF NOT EXIST %VSWHERE% SET VSWHERE="%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+IF EXIST %VSWHERE% (
+    FOR /F "usebackq tokens=*" %%i IN (`%VSWHERE% -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) DO (
+        SET VS_INSTALL_PATH=%%i
+    )
+)
+IF DEFINED VS_INSTALL_PATH (
+    ECHO Found Visual Studio at: %VS_INSTALL_PATH%
+    call "%VS_INSTALL_PATH%\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_PLATFORM%
+    goto GITSECTION
+)
+
+rem Fall back to VS2015
 IF EXIST "%VS140COMNTOOLS%..\..\"                             GOTO VC_Common_15
 IF EXIST "\Program Files\Microsoft Visual Studio 14.0\"       GOTO VC_32_15
 IF EXIST "\Program Files (x86)\Microsoft Visual Studio 14.0\" GOTO VC_64_15


### PR DESCRIPTION
…ection

steamshim_child.c: Fix float stat values being silently truncated to integers. In processEvent(), SHIMEVENT_SETSTATF/GETSTATF was assigning float values as:

    event.fvalue = (int)*((float *)buf);

The erroneous (int) cast discarded the fractional part before assigning to the float field. This meant stats like stat_online_minutes_played (a float) were always rounded down to whole numbers. Remove the cast so the float value is assigned directly.

steamshim_parent/Makefile: Update macOS redistributable library path from osx32 to osx. Valve renamed the directory when they dropped 32-bit macOS support in Steamworks SDK ~1.42 (2018). Building the Steam shim for HOST=osx would fail to link because the path no longer exists in any recent SDK.

steamshim_parent/build.bat: Add support for Visual Studio 2017, 2019, and 2022. Previously the script only detected VS2015 (VS140COMNTOOLS). Now it first tries vswhere.exe (available since VS2017, the standard Microsoft-recommended discovery mechanism) to locate the latest installed VS with C++ tools. Falls back to the legacy VS2015 check if vswhere is not found.