### PR TITLE
fix: Match group keys by scancode as well as keysym (#360)

### DIFF
--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -4823,8 +4823,7 @@ bool Game::sdlKeyDown(SDL_KeyboardEvent key) {
                    key.keysym.mod, groupHotKey, key.keysym.sym, keyName.c_str(), isKeyPressed(groupHotKey, key));
         // printf(" group key check %d   scancode:%d sym:%d groupHotKey=%d
         // \n",idx,key.keysym.scancode,key.keysym.sym,groupHotKey);
-        if (key.keysym.sym == groupHotKey ||
-            key.keysym.scancode == SDL_GetScancodeFromKey(groupHotKey)) {
+        if (key.keysym.sym == groupHotKey || key.keysym.scancode == SDL_GetScancodeFromKey(groupHotKey)) {
             if (SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled)
                 SystemFlags::OutputDebug(SystemFlags::debugSystem, "In [%s::%s Line: %d]\n", extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__,
                                          __LINE__);

--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -4823,7 +4823,8 @@ bool Game::sdlKeyDown(SDL_KeyboardEvent key) {
                    key.keysym.mod, groupHotKey, key.keysym.sym, keyName.c_str(), isKeyPressed(groupHotKey, key));
         // printf(" group key check %d   scancode:%d sym:%d groupHotKey=%d
         // \n",idx,key.keysym.scancode,key.keysym.sym,groupHotKey);
-        if (key.keysym.sym == groupHotKey) {
+        if (key.keysym.sym == groupHotKey ||
+            key.keysym.scancode == SDL_GetScancodeFromKey(groupHotKey)) {
             if (SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled)
                 SystemFlags::OutputDebug(SystemFlags::debugSystem, "In [%s::%s Line: %d]\n", extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__,
                                          __LINE__);


### PR DESCRIPTION
On ARM Linux (Raspberry Pi 5) SDL2 uses the Wayland backend with libxkbcommon, which can transform keysym.sym for modifier+key combinations so that Ctrl+1 no longer matches SDLK_1. Scancodes represent the physical key position and are unaffected by modifier state or backend differences.

Add a scancode fallback: convert the configured SDL_Keycode to its corresponding SDL_Scancode via SDL_GetScancodeFromKey() and accept a match on either sym or scancode, so Ctrl+Num group keys work on all platforms.

Fixes #360