### PR TITLE
ci: Broaden AppImage path filters to include source, scripts, and docs

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,11 +13,9 @@ on:
   push:
     branches: develop
     paths: &appimage_paths
-    - '**/appimage.yml'
-    - '**/docker-compose.yml'
-    - '**/build-appimage.sh'
-    - '**/AppRun'
-    - '**/.env'
+    - '**'
+    - '!**.yml'
+    - '.github/workflows/appimage.yml'
   pull_request:
     branches: develop
     paths: *appimage_paths


### PR DESCRIPTION
## Summary

- Replaces the narrow AppImage-specific path list with the same broad pattern used by the other CI workflows
- Now triggers on any source code, script, or document change (`.md` files included), not just AppImage build scripts
- Other workflow `.yml` files are excluded (to avoid redundant runs), but `appimage.yml` itself re-included

## Test plan
- [ ] Verify the workflow triggers on a source code change to `develop`
- [ ] Verify the workflow triggers on a `.md` doc change
- [ ] Verify the workflow does NOT trigger when only an unrelated workflow `.yml` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)