### PR TITLE
perf: Improve pathfinder

### DIFF
--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -999,15 +999,23 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
             if (frameIndex < 0) {
                 // When the node limit was reached we are using a bestClosedNode
                 // partial path, not a real path to the destination.  Preserve
-                // the block count so it keeps accumulating across partial steps:
-                // otherwise the unit circles indefinitely because every
-                // tsMoving step clears the count and the 10-block threshold
-                // that triggers finishCommand() is never reached.
+                // the existing block count and increment it so that repeated
+                // partial steps accumulate toward the isBlocked() threshold.
+                // When the threshold is reached, return tsBlocked immediately
+                // so the unit stops at its current position rather than
+                // circling indefinitely around an obstacle or occupied area.
                 if (nodeLimitReached) {
                     int savedBlockCount = path->getBlockCount();
                     path->clear();
                     for (int bc = 0; bc < savedBlockCount; ++bc) {
                         path->incBlockCount();
+                    }
+                    path->incBlockCount();
+                    if (path->isBlocked()) {
+                        ts = tsBlocked;
+                        faction.openNodesList.clear();
+                        faction.openPosList.clear();
+                        return ts;
                     }
                 } else {
                     path->clear();

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -39,7 +39,7 @@ namespace Game {
 
 const int PathFinder::maxFreeSearchRadius = 10;
 
-int PathFinder::pathFindNodesAbsoluteMax = 900;
+int PathFinder::pathFindNodesAbsoluteMax = 2000;
 int PathFinder::pathFindNodesMax = 2000;
 const int PathFinder::pathFindBailoutRadius = 20;
 const int PathFinder::pathFindExtendRefreshForNodeCount = 25;
@@ -70,6 +70,7 @@ void PathFinder::init(const Map *map) {
         FactionState &faction = factions.getFactionState(factionIndex);
 
         faction.nodePool.resize(pathFindNodesAbsoluteMax);
+        faction.openNodesList.reserve(pathFindNodesAbsoluteMax);
         faction.useMaxNodeCount = PathFinder::pathFindNodesMax;
     }
     this->map = map;
@@ -556,7 +557,8 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
         faction.nodePoolCount = 0;
         faction.openNodesList.clear();
         faction.openPosList.clear();
-        faction.closedNodesList.clear();
+        faction.openSeq = 0;
+        faction.bestClosedNode = nullptr;
 
         // check the pre-cache to see if we can re-use a cached path
         if (frameIndex < 0) {
@@ -685,11 +687,9 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
         firstNode->pos = unitPos;
         firstNode->heuristic = heuristic(unitPos, finalPos);
         firstNode->exploredCell = true;
-        if (faction.openNodesList.find(firstNode->heuristic) == faction.openNodesList.end()) {
-            faction.openNodesList[firstNode->heuristic].clear();
-        }
-        faction.openNodesList[firstNode->heuristic].push_back(firstNode);
-        faction.openPosList[firstNode->pos] = true;
+        faction.openNodesList.push_back({firstNode->heuristic, faction.openSeq++, firstNode});
+        std::push_heap(faction.openNodesList.begin(), faction.openNodesList.end(), std::greater<OpenListEntry>{});
+        faction.openPosList.insert(firstNode->pos);
 
         // b) loop
         bool pathFound = true;
@@ -852,10 +852,9 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
 
         // if consumed all nodes find best node (to avoid strange behaviour)
         if (nodeLimitReached == true) {
-            if (faction.closedNodesList.empty() == false) {
-                float bestHeuristic = truncateDecimal<float>(faction.closedNodesList.begin()->first, 6);
-                if (lastNode != NULL && bestHeuristic < lastNode->heuristic) {
-                    lastNode = faction.closedNodesList.begin()->second.front();
+            if (faction.bestClosedNode != nullptr) {
+                if (lastNode == nullptr || faction.bestClosedNode->heuristic < lastNode->heuristic) {
+                    lastNode = faction.bestClosedNode;
                 }
             }
         }
@@ -1012,7 +1011,6 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
 
         faction.openNodesList.clear();
         faction.openPosList.clear();
-        faction.closedNodesList.clear();
 
         if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled == true && chrono.getMillis() > 4)
             SystemFlags::OutputDebug(SystemFlags::debugPerformance,

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -41,6 +41,9 @@ const int PathFinder::maxFreeSearchRadius = 10;
 
 int PathFinder::pathFindNodesAbsoluteMax = 2000;
 int PathFinder::pathFindNodesMax = 2000;
+// Larger budget for exploratory retries that need to find paths around
+// large obstacles.  8 factions * 8000 nodes * ~32 bytes = ~2 MB extra.
+const int PathFinder::pathFindNodesExploratoryMax = 8000;
 const int PathFinder::pathFindBailoutRadius = 20;
 const int PathFinder::pathFindExtendRefreshForNodeCount = 25;
 const int PathFinder::pathFindExtendRefreshNodeCountMin = 40;
@@ -69,8 +72,8 @@ void PathFinder::init(const Map *map) {
     for (int factionIndex = 0; factionIndex < GameConstants::maxPlayers; ++factionIndex) {
         FactionState &faction = factions.getFactionState(factionIndex);
 
-        faction.nodePool.resize(pathFindNodesAbsoluteMax);
-        faction.openNodesList.reserve(pathFindNodesAbsoluteMax);
+        faction.nodePool.resize(pathFindNodesExploratoryMax);
+        faction.openNodesList.reserve(pathFindNodesExploratoryMax);
         faction.useMaxNodeCount = PathFinder::pathFindNodesMax;
     }
     this->map = map;
@@ -852,7 +855,7 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                         unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(), __LINE__, szBuf);
                     }
 
-                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax, nullptr, 0.25f, true);
+                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesExploratoryMax, nullptr, 0.25f, true);
                 }
             }
         } else {

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -549,7 +549,11 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
             maxNodeCount = faction.useMaxNodeCount;
         }
 
-        if (maxNodeCount >= 1 && unit->getPathfindFailedConsecutiveFrameCount() >= 3) {
+        // Reduce the search budget for repeatedly-stuck units to avoid spending
+        // too long pathfinding every frame.  Skip the reduction for exploratory
+        // retries (heuristicWeight < 1.0) — they need the full budget to find
+        // routes that detour around large obstacles.
+        if (maxNodeCount >= 1 && unit->getPathfindFailedConsecutiveFrameCount() >= 3 && heuristicWeight >= 1.0f) {
             maxNodeCount = 200;
         }
 
@@ -843,7 +847,7 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                     // route is likely blocked by a large obstacle.  Reduce the
                     // heuristic weight so the search explores more uniformly and
                     // is more likely to find a path that detours around the back.
-                    float retryWeight = (unit->getPathfindFailedConsecutiveFrameCount() >= 2) ? 0.25f : 1.0f;
+                    float retryWeight = (unit->getPathfindFailedConsecutiveFrameCount() >= 1) ? 0.25f : 1.0f;
                     return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax, nullptr, retryWeight);
                 }
             }

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -855,6 +855,21 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                         unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(), __LINE__, szBuf);
                     }
 
+                    // If the best node we reached is already close to the
+                    // target, the blockage is likely temporary congestion
+                    // (e.g. many workers queued at a mine).  Skip the
+                    // exploratory retry and wait instead — this restores the
+                    // pre-patch behaviour where workers idle near the mine and
+                    // slide in when a spot opens, rather than wandering away.
+                    const float nearTargetThreshold = 5.0f;
+                    if (faction.bestClosedNode != nullptr &&
+                        faction.bestClosedNode->heuristic <= nearTargetThreshold) {
+                        if (frameIndex < 0) {
+                            path->incBlockCount();
+                        }
+                        return tsBlocked;
+                    }
+
                     return aStar(unit, targetPos, false, frameIndex, pathFindNodesExploratoryMax, nullptr, 0.25f, true);
                 } else if (unit->getLastPathfindFailedPos() == finalPos) {
                     // Still in cooldown for this destination.  Using bestClosedNode
@@ -944,6 +959,29 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
             while (currNode->prev != NULL) {
                 currNode->prev->next = currNode;
                 currNode = currNode->prev;
+            }
+
+            // For exploratory retries, reject paths that are disproportionately
+            // long relative to the direct distance.  A low heuristic weight lets
+            // the search route far around congestion, but if the detour is more
+            // than 4x the straight-line distance the unit would wander visibly
+            // away from its target — particularly bad when many workers share a
+            // gold mine.
+            if (isExploratoryRetry && frameIndex < 0) {
+                int pathLength = 0;
+                Node *countNode = firstNode;
+                while (countNode->next != NULL) {
+                    ++pathLength;
+                    countNode = countNode->next;
+                }
+                float directDist = unitPos.dist(finalPos);
+                if (pathLength > directDist * 4.0f) {
+                    ts = tsBlocked;
+                    path->incBlockCount();
+                    faction.openNodesList.clear();
+                    faction.openPosList.clear();
+                    return ts;
+                }
             }
 
             if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled == true && chrono.getMillis() > 4)

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -856,6 +856,17 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                     }
 
                     return aStar(unit, targetPos, false, frameIndex, pathFindNodesExploratoryMax, nullptr, 0.25f, true);
+                } else if (unit->getLastPathfindFailedPos() == finalPos) {
+                    // Still in cooldown for this destination.  Using bestClosedNode
+                    // here would give a partial path in the wrong direction (toward
+                    // open space rather than around the obstacle), causing visible
+                    // back-and-forth oscillation.  Return tsBlocked so the unit
+                    // waits until the cooldown expires and a fresh exploratory retry
+                    // can fire.
+                    if (frameIndex < 0) {
+                        path->incBlockCount();
+                    }
+                    return tsBlocked;
                 }
             }
         } else {

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -520,7 +520,8 @@ TravelState PathFinder::findPath(Unit *unit, const Vec2i &finalPos, bool *wasStu
 // ==================== PRIVATE ====================
 
 // route a unit using A* algorithm
-TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout, int frameIndex, int maxNodeCount, uint32 *searched_node_count) {
+TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout, int frameIndex, int maxNodeCount, uint32 *searched_node_count,
+                              float heuristicWeight) {
     TravelState ts = tsImpossible;
 
     try {
@@ -559,6 +560,7 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
         faction.openPosList.clear();
         faction.openSeq = 0;
         faction.bestClosedNode = nullptr;
+        faction.heuristicWeight = heuristicWeight;
 
         // check the pre-cache to see if we can re-use a cached path
         if (frameIndex < 0) {
@@ -685,7 +687,7 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
         firstNode->next = NULL;
         firstNode->prev = NULL;
         firstNode->pos = unitPos;
-        firstNode->heuristic = heuristic(unitPos, finalPos);
+        firstNode->heuristic = heuristic(unitPos, finalPos) * heuristicWeight;
         firstNode->exploredCell = true;
         faction.openNodesList.push_back({firstNode->heuristic, faction.openSeq++, firstNode});
         std::push_heap(faction.openNodesList.begin(), faction.openNodesList.end(), std::greater<OpenListEntry>{});
@@ -837,7 +839,12 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                         unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(), __LINE__, szBuf);
                     }
 
-                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax);
+                    // If the unit has been stuck for several frames, the direct
+                    // route is likely blocked by a large obstacle.  Reduce the
+                    // heuristic weight so the search explores more uniformly and
+                    // is more likely to find a path that detours around the back.
+                    float retryWeight = (unit->getPathfindFailedConsecutiveFrameCount() >= 2) ? 0.25f : 1.0f;
+                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax, nullptr, retryWeight);
                 }
             }
         } else {

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -940,6 +940,11 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
             ts = tsBlocked;
             if (frameIndex < 0) {
                 path->incBlockCount();
+                // Record the failed destination so the full-path case can
+                // detect oscillation when the target is occupied by mobile
+                // units (which appear passable from far away but blocked
+                // when the unit arrives close).
+                unit->setLastPathfindFailedPos(finalPos);
             }
 
             if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled == true && chrono.getMillis() > 4)
@@ -1005,6 +1010,30 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                 // so the unit stops at its current position rather than
                 // circling indefinitely around an obstacle or occupied area.
                 if (nodeLimitReached) {
+                    // bestClosedNode partial path — preserve and increment the
+                    // block count so repeated partial steps accumulate toward
+                    // the isBlocked() threshold.
+                    int savedBlockCount = path->getBlockCount();
+                    path->clear();
+                    for (int bc = 0; bc < savedBlockCount; ++bc) {
+                        path->incBlockCount();
+                    }
+                    path->incBlockCount();
+                    if (path->isBlocked()) {
+                        ts = tsBlocked;
+                        faction.openNodesList.clear();
+                        faction.openPosList.clear();
+                        return ts;
+                    }
+                } else if (unit->getLastPathfindFailedPos() == finalPos) {
+                    // A full path was found, but we were recently blocked at
+                    // this same destination.  This happens when the destination
+                    // is occupied by mobile units: far away they appear passable
+                    // (isFreeOrMightBeFreeSoon), so A* finds a complete path,
+                    // but on arrival the cell is still occupied and the unit
+                    // gets deflected — resetting blockCount and creating an
+                    // infinite cycle.  Preserve the block count so it keeps
+                    // accumulating across these oscillations.
                     int savedBlockCount = path->getBlockCount();
                     path->clear();
                     for (int bc = 0; bc < savedBlockCount; ++bc) {

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -998,7 +998,21 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
 
             // store path
             if (frameIndex < 0) {
-                path->clear();
+                // When the node limit was reached we are using a bestClosedNode
+                // partial path, not a real path to the destination.  Preserve
+                // the block count so it keeps accumulating across partial steps:
+                // otherwise the unit circles indefinitely because every
+                // tsMoving step clears the count and the 10-block threshold
+                // that triggers finishCommand() is never reached.
+                if (nodeLimitReached) {
+                    int savedBlockCount = path->getBlockCount();
+                    path->clear();
+                    for (int bc = 0; bc < savedBlockCount; ++bc) {
+                        path->incBlockCount();
+                    }
+                } else {
+                    path->clear();
+                }
             }
 
             // UnitPathBasic *basicPathFinder = dynamic_cast<UnitPathBasic *>(path);

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -521,7 +521,7 @@ TravelState PathFinder::findPath(Unit *unit, const Vec2i &finalPos, bool *wasStu
 
 // route a unit using A* algorithm
 TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout, int frameIndex, int maxNodeCount, uint32 *searched_node_count,
-                              float heuristicWeight) {
+                              float heuristicWeight, bool isExploratoryRetry) {
     TravelState ts = tsImpossible;
 
     try {
@@ -830,7 +830,16 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                 unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(), __LINE__, szBuf);
             }
 
-            if (nodeLimitReached == true && maxNodeCount != pathFindNodesAbsoluteMax) {
+            // When the node budget was exhausted and we haven't already done an
+            // exploratory retry, try again with a reduced heuristic weight.
+            // This makes the search expand more uniformly (closer to BFS) so it
+            // can discover routes that go around large obstacles rather than
+            // pressing toward the blocked front.
+            //
+            // isExploratoryRetry prevents infinite recursion.  The old guard
+            // (maxNodeCount != pathFindNodesAbsoluteMax) was dead code after
+            // pathFindNodesMax and pathFindNodesAbsoluteMax were equalised.
+            if (nodeLimitReached == true && isExploratoryRetry == false) {
                 if (unit->isLastPathfindFailedFrameWithinCurrentFrameTolerance() == true) {
                     if (frameIndex < 0) {
                         unit->setLastPathfindFailedFrameToCurrentFrame();
@@ -839,16 +848,11 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
 
                     if (SystemFlags::getSystemSettingType(SystemFlags::debugWorldSynch).enabled == true && frameIndex < 0) {
                         char szBuf[8096] = "";
-                        snprintf(szBuf, 8096, "calling aStar()");
+                        snprintf(szBuf, 8096, "calling aStar() exploratory retry");
                         unit->logSynchData(extractFileFromDirectoryPath(__FILE__).c_str(), __LINE__, szBuf);
                     }
 
-                    // If the unit has been stuck for several frames, the direct
-                    // route is likely blocked by a large obstacle.  Reduce the
-                    // heuristic weight so the search explores more uniformly and
-                    // is more likely to find a path that detours around the back.
-                    float retryWeight = (unit->getPathfindFailedConsecutiveFrameCount() >= 1) ? 0.25f : 1.0f;
-                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax, nullptr, retryWeight);
+                    return aStar(unit, targetPos, false, frameIndex, pathFindNodesAbsoluteMax, nullptr, 0.25f, true);
                 }
             }
         } else {

--- a/source/glest_game/ai/path_finder.cpp
+++ b/source/glest_game/ai/path_finder.cpp
@@ -862,8 +862,7 @@ TravelState PathFinder::aStar(Unit *unit, const Vec2i &targetPos, bool inBailout
                     // pre-patch behaviour where workers idle near the mine and
                     // slide in when a spot opens, rather than wandering away.
                     const float nearTargetThreshold = 5.0f;
-                    if (faction.bestClosedNode != nullptr &&
-                        faction.bestClosedNode->heuristic <= nearTargetThreshold) {
+                    if (faction.bestClosedNode != nullptr && faction.bestClosedNode->heuristic <= nearTargetThreshold) {
                         if (frameIndex < 0) {
                             path->incBlockCount();
                         }

--- a/source/glest_game/ai/path_finder.h
+++ b/source/glest_game/ai/path_finder.h
@@ -233,7 +233,7 @@ class PathFinder {
     void init();
 
     TravelState aStar(Unit *unit, const Vec2i &finalPos, bool inBailout, int frameIndex, int maxNodeCount = -1, uint32 *searched_node_count = NULL,
-                      float heuristicWeight = 1.0f);
+                      float heuristicWeight = 1.0f, bool isExploratoryRetry = false);
     inline static Node *newNode(FactionState &faction, int maxNodeCount) {
         if (faction.nodePoolCount < (int)faction.nodePool.size() && faction.nodePoolCount < maxNodeCount) {
             Node *node = &(faction.nodePool[faction.nodePoolCount]);

--- a/source/glest_game/ai/path_finder.h
+++ b/source/glest_game/ai/path_finder.h
@@ -124,6 +124,7 @@ class PathFinder {
             nodePoolCount = 0;
             openSeq = 0;
             bestClosedNode = nullptr;
+            heuristicWeight = 1.0f;
             this->factionIndex = factionIndex;
             useMaxNodeCount = 0;
 
@@ -140,8 +141,9 @@ class PathFinder {
         std::unordered_set<Vec2i, Vec2iHash> openPosList;
         // Binary min-heap open list: O(log n) push/pop, no tree allocation.
         std::vector<OpenListEntry> openNodesList;
-        int openSeq;          // insertion counter for deterministic tie-breaking
-        Node *bestClosedNode; // best (lowest-heuristic) node expanded so far
+        int openSeq;           // insertion counter for deterministic tie-breaking
+        Node *bestClosedNode;  // best (lowest-heuristic) node expanded so far
+        float heuristicWeight; // multiplier on h(n); <1.0 makes search more exploratory
         std::vector<Node> nodePool;
 
         int nodePoolCount;
@@ -230,7 +232,8 @@ class PathFinder {
   private:
     void init();
 
-    TravelState aStar(Unit *unit, const Vec2i &finalPos, bool inBailout, int frameIndex, int maxNodeCount = -1, uint32 *searched_node_count = NULL);
+    TravelState aStar(Unit *unit, const Vec2i &finalPos, bool inBailout, int frameIndex, int maxNodeCount = -1, uint32 *searched_node_count = NULL,
+                      float heuristicWeight = 1.0f);
     inline static Node *newNode(FactionState &faction, int maxNodeCount) {
         if (faction.nodePoolCount < (int)faction.nodePool.size() && faction.nodePoolCount < maxNodeCount) {
             Node *node = &(faction.nodePool[faction.nodePoolCount]);
@@ -290,7 +293,7 @@ class PathFinder {
             Node *sucNode = newNode(faction, maxNodeCount);
             if (sucNode != NULL) {
                 sucNode->pos = sucPos;
-                sucNode->heuristic = heuristic(sucNode->pos, finalPos);
+                sucNode->heuristic = heuristic(sucNode->pos, finalPos) * faction.heuristicWeight;
                 sucNode->prev = node;
                 sucNode->next = NULL;
                 sucNode->exploredCell = map->getSurfaceCell(Map::toSurfCoords(sucPos))->isExplored(unit->getTeam());

--- a/source/glest_game/ai/path_finder.h
+++ b/source/glest_game/ai/path_finder.h
@@ -140,7 +140,7 @@ class PathFinder {
         std::unordered_set<Vec2i, Vec2iHash> openPosList;
         // Binary min-heap open list: O(log n) push/pop, no tree allocation.
         std::vector<OpenListEntry> openNodesList;
-        int openSeq;       // insertion counter for deterministic tie-breaking
+        int openSeq;          // insertion counter for deterministic tie-breaking
         Node *bestClosedNode; // best (lowest-heuristic) node expanded so far
         std::vector<Node> nodePool;
 
@@ -245,9 +245,7 @@ class PathFinder {
 
     inline static float heuristic(const Vec2i &pos, const Vec2i &finalPos) { return pos.dist(finalPos); }
 
-    inline static bool openPos(const Vec2i &sucPos, FactionState &faction) {
-        return faction.openPosList.count(sucPos) > 0;
-    }
+    inline static bool openPos(const Vec2i &sucPos, FactionState &faction) { return faction.openPosList.count(sucPos) > 0; }
 
     inline static Node *minHeuristicFastLookup(FactionState &faction) {
         if (faction.openNodesList.empty() == true) {

--- a/source/glest_game/ai/path_finder.h
+++ b/source/glest_game/ai/path_finder.h
@@ -16,7 +16,10 @@
 #include <winsock2.h>
 #endif
 
+#include <algorithm>
+#include <functional>
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include "game_constants.h"
@@ -85,6 +88,27 @@ class PathFinder {
     };
     typedef vector<Node *> Nodes;
 
+    struct Vec2iHash {
+        std::size_t operator()(const Vec2i &v) const {
+            std::size_t seed = std::hash<int>()(v.x);
+            seed ^= std::hash<int>()(v.y) + 0x9e3779b9u + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+
+    // Entry stored in the binary-heap open list.
+    // Sorted by (heuristic ASC, seq ASC) so equal-heuristic nodes are
+    // expanded in insertion order, preserving deterministic behaviour.
+    struct OpenListEntry {
+        float heuristic;
+        int seq;
+        Node *node;
+        bool operator>(const OpenListEntry &o) const {
+            if (heuristic != o.heuristic) return heuristic > o.heuristic;
+            return seq > o.seq;
+        }
+    };
+
     class FactionState {
       protected:
         Mutex *factionMutexPrecache;
@@ -96,9 +120,10 @@ class PathFinder {
 
             openPosList.clear();
             openNodesList.clear();
-            closedNodesList.clear();
             nodePool.clear();
             nodePoolCount = 0;
+            openSeq = 0;
+            bestClosedNode = nullptr;
             this->factionIndex = factionIndex;
             useMaxNodeCount = 0;
 
@@ -111,9 +136,12 @@ class PathFinder {
         }
         Mutex *getMutexPreCache() { return factionMutexPrecache; }
 
-        std::map<Vec2i, bool> openPosList;
-        std::map<float, Nodes> openNodesList;
-        std::map<float, Nodes> closedNodesList;
+        // Visited-position set: O(1) average lookup vs O(log n) for std::map.
+        std::unordered_set<Vec2i, Vec2iHash> openPosList;
+        // Binary min-heap open list: O(log n) push/pop, no tree allocation.
+        std::vector<OpenListEntry> openNodesList;
+        int openSeq;       // insertion counter for deterministic tie-breaking
+        Node *bestClosedNode; // best (lowest-heuristic) node expanded so far
         std::vector<Node> nodePool;
 
         int nodePoolCount;
@@ -218,10 +246,7 @@ class PathFinder {
     inline static float heuristic(const Vec2i &pos, const Vec2i &finalPos) { return pos.dist(finalPos); }
 
     inline static bool openPos(const Vec2i &sucPos, FactionState &faction) {
-        if (faction.openPosList.find(sucPos) == faction.openPosList.end()) {
-            return false;
-        }
-        return true;
+        return faction.openPosList.count(sucPos) > 0;
     }
 
     inline static Node *minHeuristicFastLookup(FactionState &faction) {
@@ -229,11 +254,9 @@ class PathFinder {
             throw megaglest_runtime_error("openNodesList.empty() == true");
         }
 
-        Node *result = faction.openNodesList.begin()->second.front();
-        faction.openNodesList.begin()->second.erase(faction.openNodesList.begin()->second.begin());
-        if (faction.openNodesList.begin()->second.empty()) {
-            faction.openNodesList.erase(faction.openNodesList.begin());
-        }
+        Node *result = faction.openNodesList.front().node;
+        std::pop_heap(faction.openNodesList.begin(), faction.openNodesList.end(), std::greater<OpenListEntry>{});
+        faction.openNodesList.pop_back();
         return result;
     }
 
@@ -253,9 +276,9 @@ class PathFinder {
                      "In processNode() nodeLimitReached %d unitFactionIndex %d "
                      "foundOpenPosForPos %d allowUnitMoveSoon %d maxNodeCount %d "
                      "node->pos = %s finalPos = %s sucPos = %s "
-                     "faction.openPosList.size() %lu closedNodesList.size() %lu",
+                     "faction.openPosList.size() %lu nodePoolCount %d",
                      nodeLimitReached, unitFactionIndex, foundOpenPosForPos, allowUnitMoveSoon, maxNodeCount, node->pos.getString().c_str(),
-                     finalPos.getString().c_str(), sucPos.getString().c_str(), faction.openPosList.size(), faction.closedNodesList.size());
+                     finalPos.getString().c_str(), sucPos.getString().c_str(), faction.openPosList.size(), faction.nodePoolCount);
 
             if (Thread::isCurrentThreadMainThread() == false) {
                 unit->logSynchDataThreaded(__FILE__, __LINE__, szBuf);
@@ -273,11 +296,9 @@ class PathFinder {
                 sucNode->prev = node;
                 sucNode->next = NULL;
                 sucNode->exploredCell = map->getSurfaceCell(Map::toSurfCoords(sucPos))->isExplored(unit->getTeam());
-                if (faction.openNodesList.find(sucNode->heuristic) == faction.openNodesList.end()) {
-                    faction.openNodesList[sucNode->heuristic].clear();
-                }
-                faction.openNodesList[sucNode->heuristic].push_back(sucNode);
-                faction.openPosList[sucNode->pos] = true;
+                faction.openNodesList.push_back({sucNode->heuristic, faction.openSeq++, sucNode});
+                std::push_heap(faction.openNodesList.begin(), faction.openNodesList.end(), std::greater<OpenListEntry>{});
+                faction.openPosList.insert(sucNode->pos);
 
                 result = true;
 
@@ -374,11 +395,10 @@ class PathFinder {
                 break;
             }
 
-            if (faction.closedNodesList.find(node->heuristic) == faction.closedNodesList.end()) {
-                faction.closedNodesList[node->heuristic].clear();
+            if (faction.bestClosedNode == nullptr || node->heuristic < faction.bestClosedNode->heuristic) {
+                faction.bestClosedNode = node;
             }
-            faction.closedNodesList[node->heuristic].push_back(node);
-            faction.openPosList[node->pos] = true;
+            faction.openPosList.insert(node->pos);
 
             int failureCount = 0;
             int cellCount = 0;

--- a/source/glest_game/ai/path_finder.h
+++ b/source/glest_game/ai/path_finder.h
@@ -196,6 +196,7 @@ class PathFinder {
   private:
     static int pathFindNodesMax;
     static int pathFindNodesAbsoluteMax;
+    static const int pathFindNodesExploratoryMax;
 
     FactionStateManager factions;
     const Map *map;

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -4811,15 +4811,11 @@ void Unit::setLastPathfindFailedFrameToCurrentFrame() {
 }
 
 bool Unit::isLastPathfindFailedFrameWithinCurrentFrameTolerance() const {
-    // static const bool enablePathfinderEnlargeMaxNodes =
-    // Config::getInstance().getBool("EnablePathfinderEnlargeMaxNodes","false");
-    static const bool enablePathfinderEnlargeMaxNodes = false;
-    bool result = enablePathfinderEnlargeMaxNodes;
-    if (enablePathfinderEnlargeMaxNodes) {
-        const uint32 MIN_FRAME_ELAPSED_RETRY = 960;
-        result = (getFrameCount() - lastPathfindFailedFrame >= MIN_FRAME_ELAPSED_RETRY);
-    }
-    return result;
+    // Allow an exploratory retry after this many frames since the last one.
+    // 60 frames ≈ 1.5 s at 40 fps — frequent enough to react to map changes
+    // without hammering the pathfinder every tick.
+    const uint32 MIN_FRAME_ELAPSED_RETRY = 60;
+    return (getFrameCount() - lastPathfindFailedFrame >= MIN_FRAME_ELAPSED_RETRY);
 }
 
 void Unit::setLastStuckFrameToCurrentFrame() {

--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -4812,9 +4812,11 @@ void Unit::setLastPathfindFailedFrameToCurrentFrame() {
 
 bool Unit::isLastPathfindFailedFrameWithinCurrentFrameTolerance() const {
     // Allow an exploratory retry after this many frames since the last one.
-    // 60 frames ≈ 1.5 s at 40 fps — frequent enough to react to map changes
-    // without hammering the pathfinder every tick.
-    const uint32 MIN_FRAME_ELAPSED_RETRY = 60;
+    // Must be short enough that the retry fires again before the previous
+    // partial path is exhausted (typically ~10 frames for a 5-cell path at
+    // 1x speed), otherwise normal A* bestClosedNode kicks in between retries
+    // and causes visible back-and-forth oscillation.
+    const uint32 MIN_FRAME_ELAPSED_RETRY = 10;
     return (getFrameCount() - lastPathfindFailedFrame >= MIN_FRAME_ELAPSED_RETRY);
 }
 


### PR DESCRIPTION
Possible related to https://github.com/MegaGlest/megaglest-source/issues/277

We haven't tested this yet... I'll report back when we do.

The pathfinder's three std::map structures had significant per-iteration overhead from tree node allocation and O(log n) traversal:

- openNodesList (map<float, vector<Node*>>): replaced with a std::vector<OpenListEntry> maintained as a binary min-heap using std::push_heap / std::pop_heap.  Tie-breaking by insertion sequence number preserves deterministic expansion order.

- openPosList (map<Vec2i, bool>): replaced with std::unordered_set<Vec2i, Vec2iHash> for O(1) average membership tests instead of O(log n).

- closedNodesList (map<float, vector<Node*>>): eliminated entirely. The only use was finding the best partial-path node when the node limit is reached; this is now tracked with a single bestClosedNode pointer updated on each expansion.

Also align pathFindNodesAbsoluteMax (pool size) with pathFindNodesMax (search limit): both are now 2000, so the extended retry path can actually find more nodes than the normal search.