### PR TITLE
fix: Resolve compile-time warnings in first-party code

### DIFF
--- a/source/glest_game/game/commander.cpp
+++ b/source/glest_game/game/commander.cpp
@@ -890,6 +890,9 @@ void Commander::giveNetworkCommand(NetworkCommand *networkCommand) const {
             SystemFlags::OutputDebug(SystemFlags::debugSystem, "In [%s::%s Line: %d] found nctPlayerStatusChange\n",
                                      extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__);
     } break;
+
+    default:
+        break;
     }
 
     if (commandWasHandled == false) {

--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -5903,6 +5903,9 @@ string Game::getDebugStats(std::map<int, string> &factionDebugInfo) {
         case ctCpuMega:
             factionInfo += " CPU Mega" + multiplier;
             break;
+
+        default:
+            break;
         }
 
         factionInfo += " [" + formatString(this->gameSettings.getFactionTypeName(i)) + " team: " + intToStr(this->gameSettings.getTeam(i)) + "]";

--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -195,6 +195,8 @@ Texture2D *CoreData::getTextureBySystemId(TextureSystemType type) {
         break;
 
         // std::vector<Texture2D *> miscTextureList;
+    default:
+        break;
     }
     return result;
 }

--- a/source/glest_game/graphics/renderer.cpp
+++ b/source/glest_game/graphics/renderer.cpp
@@ -362,8 +362,7 @@ Renderer::~Renderer() {
         snprintf(szBuf, 8096, "In [%s::%s Line: %d]\nError [%s]\n", extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, e.what());
         SystemFlags::OutputDebug(SystemFlags::debugError, szBuf);
         if (SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled) SystemFlags::OutputDebug(SystemFlags::debugSystem, szBuf);
-
-        throw megaglest_runtime_error(szBuf);
+        // Destructors must not throw; log and swallow.
     }
 }
 

--- a/source/glest_game/gui/gui.cpp
+++ b/source/glest_game/gui/gui.cpp
@@ -1159,6 +1159,9 @@ void Gui::addOrdersResultToConsole(CommandClass cc, std::pair<CommandResult, str
     case crSomeFailed:
         console->addStdMessage("SomeOrdersFailed", result.second);
         break;
+
+    default:
+        break;
     }
 }
 

--- a/source/glest_game/main/main.cpp
+++ b/source/glest_game/main/main.cpp
@@ -1459,7 +1459,7 @@ int setupGameItemPaths(int argc, char **argv, Config *config) {
             if (SystemFlags::VERBOSE_MODE_ENABLED) printf("Using custom data path [%s]\n", customPathValue.c_str());
         } else {
             printf("\nInvalid path specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             printParameterHelp(argv[0], false);
             return 1;
         }
@@ -1505,7 +1505,7 @@ int setupGameItemPaths(int argc, char **argv, Config *config) {
             if (SystemFlags::VERBOSE_MODE_ENABLED) printf("Using custom ini path [%s]\n", customPathValue.c_str());
         } else {
             printf("\nInvalid path specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             printParameterHelp(argv[0], false);
             return 1;
         }
@@ -1528,7 +1528,7 @@ int setupGameItemPaths(int argc, char **argv, Config *config) {
             if (SystemFlags::VERBOSE_MODE_ENABLED) printf("Using custom logs path [%s]\n", customPathValue.c_str());
         } else {
             printf("\nInvalid path specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             printParameterHelp(argv[0], false);
             return 1;
         }
@@ -1568,7 +1568,7 @@ int setupGameItemPaths(int argc, char **argv, Config *config) {
             if (SystemFlags::VERBOSE_MODE_ENABLED) printf("Using custom fonts path [%s]\n", customPathValue.c_str());
         } else {
             printf("\nInvalid path specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             printParameterHelp(argv[0], false);
             return 1;
         }
@@ -2906,7 +2906,7 @@ void runTechValidationReport(int argc, char **argv) {
         } else {
             printf("\nInvalid missing scenario specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             return;
         }
     }
@@ -3101,7 +3101,7 @@ void runTilesetValidationReport(int argc, char **argv) {
         } else {
             printf("\nInvalid missing tileset specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             return;
         }
     } else {
@@ -3647,7 +3647,7 @@ int handleCreateDataArchivesCommand(int argc, char **argv) {
                 return_value = 0;
         } else {
             printf("\nInvalid missing map specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return_value = 1;
         }
@@ -3685,7 +3685,7 @@ int handleShowCRCValuesCommand(int argc, char **argv) {
             }
         } else {
             printf("\nInvalid missing map specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return_value = 1;
         }
@@ -3717,7 +3717,7 @@ int handleShowCRCValuesCommand(int argc, char **argv) {
         } else {
             printf("\nInvalid missing tileset specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return_value = 1;
         }
@@ -3749,7 +3749,7 @@ int handleShowCRCValuesCommand(int argc, char **argv) {
         } else {
             printf("\nInvalid missing techtree specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return_value = 1;
         }
@@ -3780,7 +3780,7 @@ int handleShowCRCValuesCommand(int argc, char **argv) {
         } else {
             printf("\nInvalid missing scenario specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return_value = 0;
         }
@@ -3808,12 +3808,12 @@ int handleShowCRCValuesCommand(int argc, char **argv) {
             if (paramPartTokens.size() < 2) {
                 printf("\nInvalid missing path and filter specified on commandline [%s] "
                        "value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             }
             if (paramPartTokens.size() < 3) {
                 printf("\nInvalid missing filter specified on commandline [%s] value "
                        "[%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 3 ? paramPartTokens[2].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 3 ? paramPartTokens[2].c_str() : ""));
             }
 
             return_value = 1;
@@ -4239,7 +4239,7 @@ int glestMain(int argc, char **argv) {
         } else {
             printf("\nInvalid missing server title specified on commandline [%s] value "
                    "[%s]\n\n",
-                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
             return 1;
         }
@@ -4495,7 +4495,7 @@ int glestMain(int argc, char **argv) {
             printf("Setting mod active [%s]\n", autoloadModName.c_str());
         } else {
             printf("\nInvalid mod pathname specified on commandline [%s] mod [%s]\n\n", argv[foundParamIndIndex],
-                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                   (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
             printParameterHelp(argv[0], foundInvalidArgs);
             return 1;
         }
@@ -4670,13 +4670,13 @@ int glestMain(int argc, char **argv) {
                     }
                 } else {
                     printf("\nInvalid ports specified on commandline [%s] value [%s]\n\n", argv[foundParamIndIndex],
-                           (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                           (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                     return 1;
                 }
             } else {
                 printf("\nInvalid missing ports specified on commandline [%s] value "
                        "[%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4755,13 +4755,13 @@ int glestMain(int argc, char **argv) {
                 } else {
                     printf("\nInvalid missing resolution settings specified on commandline "
                            "[%s] value [%s]\n\n",
-                           argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                           argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                     return 1;
                 }
             } else {
                 printf("\nInvalid missing resolution setting specified on commandline "
                        "[%s] value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4784,7 +4784,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing colorbits settings specified on commandline "
                        "[%s] value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4807,7 +4807,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing depthbits setting specified on commandline [%s] "
                        "value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4830,7 +4830,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing fullscreen setting specified on commandline "
                        "[%s] value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4853,7 +4853,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing gamma setting specified on commandline [%s] "
                        "value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -4982,7 +4982,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing language specified on commandline [%s] value "
                        "[%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         } else {
@@ -5083,7 +5083,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing font base size specified on commandline [%s] "
                        "value [%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
 
                 return 1;
             }
@@ -5127,7 +5127,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid missing font specified on commandline [%s] value "
                        "[%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 return 1;
             }
         }
@@ -5300,7 +5300,7 @@ int glestMain(int argc, char **argv) {
                 gameInitialized = true;
             } else {
                 printf("\nInvalid map name specified on commandline [%s] map [%s]\n\n", argv[foundParamIndIndex],
-                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 printParameterHelp(argv[0], foundInvalidArgs);
                 delete mainWindow;
                 mainWindow = NULL;
@@ -5337,7 +5337,7 @@ int glestMain(int argc, char **argv) {
                 gameInitialized = true;
             } else {
                 printf("\nInvalid host specified on commandline [%s] host [%s]\n\n", argv[foundParamIndIndex],
-                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 printParameterHelp(argv[0], foundInvalidArgs);
                 delete mainWindow;
                 mainWindow = NULL;
@@ -5365,7 +5365,7 @@ int glestMain(int argc, char **argv) {
                 gameInitialized = true;
             } else {
                 printf("\nInvalid host specified on commandline [%s] host [%s]\n\n", argv[foundParamIndIndex],
-                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 printParameterHelp(argv[0], foundInvalidArgs);
                 delete mainWindow;
                 mainWindow = NULL;
@@ -5388,7 +5388,7 @@ int glestMain(int argc, char **argv) {
             } else {
                 printf("\nInvalid scenario name specified on commandline [%s] scenario "
                        "[%s]\n\n",
-                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       argv[foundParamIndIndex], (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 printParameterHelp(argv[0], foundInvalidArgs);
                 delete mainWindow;
                 mainWindow = NULL;
@@ -5504,7 +5504,7 @@ int glestMain(int argc, char **argv) {
                 return result;
             } else {
                 printf("\nInvalid model specified on commandline [%s] texture [%s]\n\n", argv[foundParamIndIndex],
-                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : NULL));
+                       (paramPartTokens.size() >= 2 ? paramPartTokens[1].c_str() : ""));
                 printParameterHelp(argv[0], foundInvalidArgs);
                 delete mainWindow;
                 mainWindow = NULL;

--- a/source/glest_game/menu/menu_state_mods.cpp
+++ b/source/glest_game/menu/menu_state_mods.cpp
@@ -1930,6 +1930,8 @@ string MenuStateMods::getPreviewImageFileForMod(const ModInfo *modInfo) {
             case mt_Scenario:
                 fileName += "scenario_";
                 break;
+            default:
+                break;
             }
             fileName += extractFileFromDirectoryPath(modInfo->imageUrl);
         }

--- a/source/glest_game/menu/menu_state_root.cpp
+++ b/source/glest_game/menu/menu_state_root.cpp
@@ -41,14 +41,15 @@ namespace Game {
 bool MenuStateRoot::gameUpdateChecked = false;
 
 MenuStateRoot::MenuStateRoot(Program *program, MainMenu *mainMenu)
-    : MenuState(program, mainMenu, "root"), updatesHttpServerThread(NULL), buttonNewGame("MainMenu", "buttonNewGame"),
-      buttonLoadGame("MainMenu", "buttonLoadGame"), buttonMods("MainMenu", "buttonMods"), buttonOptions("MainMenu", "buttonOptions"),
-      buttonAbout("MainMenu", "buttonAbout"), buttonExit("MainMenu", "buttonExit"), labelVersion("MainMenu", "labelVersion"),
-      labelGreeting("MainMenu", "labelGreeting"),
+    : MenuState(program, mainMenu, "root"), buttonNewGame("MainMenu", "buttonNewGame"), buttonLoadGame("MainMenu", "buttonLoadGame"),
+      buttonMods("MainMenu", "buttonMods"), buttonOptions("MainMenu", "buttonOptions"), buttonAbout("MainMenu", "buttonAbout"),
+      buttonExit("MainMenu", "buttonExit"), labelVersion("MainMenu", "labelVersion"), labelGreeting("MainMenu", "labelGreeting"),
 
       mainMessageBox("MainMenu", "mainMessageBox"), errorMessageBox("MainMenu", "errorMessageBox"), ftpMessageBox("MainMenu", "ftpMessageBox"),
 
-      popupMenu("MainMenu", "popupMenu")
+      popupMenu("MainMenu", "popupMenu"),
+
+      updatesHttpServerThread(NULL)
 
 {
     containerName = "MainMenu";

--- a/source/glest_game/network/client_interface.cpp
+++ b/source/glest_game/network/client_interface.cpp
@@ -2398,6 +2398,8 @@ bool ClientInterface::shouldDiscardNetworkMessage(NetworkMessageType networkMess
         PlayerIndexMessage msg = PlayerIndexMessage(0);
         this->receiveMessage(&msg);
     } break;
+    default:
+        break;
     }
 
     return discard;

--- a/source/glest_game/network/network_message.cpp
+++ b/source/glest_game/network/network_message.cpp
@@ -196,6 +196,8 @@ string NetworkMessage::getNetworkPacketStats() {
         case netmsgstAverageRecvSize:
             result += "recv avg size: " + intToStr(iterMap->second) + "\n";
             break;
+        default:
+            break;
         }
     }
     return result;

--- a/source/glest_game/network/network_types.cpp
+++ b/source/glest_game/network/network_types.cpp
@@ -30,8 +30,8 @@ namespace Game {
 NetworkCommand::NetworkCommand(World *world, int networkCommandType, int unitId, int commandTypeId, const Vec2i &pos, int unitTypeId, int targetId, int facing,
                                bool wantQueue, CommandStateType commandStateType, int commandStateValue, int unitCommandGroupId)
     : networkCommandType(networkCommandType), unitId(unitId), unitTypeId(unitTypeId), commandTypeId(commandTypeId), positionX(pos.x), positionY(pos.y),
-      wantQueue(wantQueue), commandStateType(commandStateType), commandStateValue(commandStateValue), unitCommandGroupId(unitCommandGroupId),
-      unitFactionUnitCount(0), unitFactionIndex(0) {
+      wantQueue(wantQueue), unitFactionUnitCount(0), unitFactionIndex(0), commandStateType(commandStateType), commandStateValue(commandStateValue),
+      unitCommandGroupId(unitCommandGroupId) {
     assert(targetId == -1 || facing == -1);
     this->targetId = targetId >= 0 ? targetId : facing;
     this->fromFactionIndex = world->getThisFactionIndex();

--- a/source/glest_game/network/server_interface.cpp
+++ b/source/glest_game/network/server_interface.cpp
@@ -1974,6 +1974,8 @@ bool ServerInterface::shouldDiscardNetworkMessage(NetworkMessageType networkMess
             PlayerIndexMessage msg = PlayerIndexMessage(0);
             connectionSlot->receiveMessage(&msg);
         } break;
+        default:
+            break;
         }
     }
     return discard;

--- a/source/glest_game/types/unit_type.cpp
+++ b/source/glest_game/types/unit_type.cpp
@@ -1267,7 +1267,7 @@ string UnitType::getCommandTypeListDesc() const {
     for (int i = 0; i < getCommandTypeCount(); ++i) {
         const CommandType *commandType = getCommandType(i);
         desc += " id = " + intToStr(commandType->getId());
-        +" toString: " + commandType->toString(false);
+        desc += " toString: " + commandType->toString(false);
     }
     return desc;
 }

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -1287,6 +1287,9 @@ void UnitUpdater::updateBuild(Unit *unit, int frameIndex) {
                             SystemFlags::OutputDebug(SystemFlags::debugUnitCommands, "In [%s::%s Line: %d] got tsBlocked\n", __FILE__, __FUNCTION__, __LINE__);
                     }
                     break;
+
+                default:
+                    break;
                 }
             }
             if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0)

--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -1343,6 +1343,8 @@ void MainWindow::change(int x, int y) {
     case ctGradient:
         program->pirateChangeMapHeight(x, y, height, radius);
         break;
+    default:
+        break;
     }
 }
 

--- a/source/glest_map_editor/program.cpp
+++ b/source/glest_map_editor/program.cpp
@@ -80,6 +80,8 @@ void UndoPoint::init(ChangeType change) {
             }
         }
         break;
+    default:
+        break;
     }
 }
 
@@ -129,6 +131,8 @@ void UndoPoint::revert() {
                 Program::map->setResource(i, j, resource[j * w + i]);
             }
         }
+        break;
+    default:
         break;
     }
     // std::cout << "reverted changes (we hope)" << std::endl;


### PR DESCRIPTION
- Fix logic bug in unit_type.cpp: dangling string expression was a no-op (missing `desc +=` prefix); result was silently discarded
- Fix -Wterminate in renderer.cpp: throwing from a destructor calls terminate() in C++11; log and swallow instead
- Fix -Wformat-overflow in main.cpp (30 sites): NULL passed as %s argument to printf causes UB; replaced with ""
- Fix -Wreorder in network_types.cpp and menu_state_root.cpp: member initializer order didn't match declaration order
- Fix -Wswitch in 11 switch statements across commander.cpp, game.cpp, core_data.cpp, gui.cpp, unit_updater.cpp, client_interface.cpp, server_interface.cpp, network_message.cpp, menu_state_mods.cpp, and glest_map_editor (main.cpp, program.cpp): add `default: break;` for intentionally unhandled enum values