### PR TITLE
ci: Add Windows build matrix entry for WANT_USE_STREFLOP=OFF

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,9 +53,14 @@ jobs:
       matrix:
         arch: [x64]
         build_type: [Release]
+        streflop: [ON, OFF]
         include:
           - build_type: Release
             release: 'ON'
+          - streflop: ON
+            streflop_suffix: ''
+          - streflop: OFF
+            streflop_suffix: '-no-streflop'
     runs-on: windows-latest
 
     steps:
@@ -72,7 +77,7 @@ jobs:
     - name: Build MegaGlest
       run: |
         cd mk/windoze
-        ./build-mg-vs-cmake.ps1 -vcpkg-location c:/vcpkg/
+        ./build-mg-vs-cmake.ps1 -vcpkg-location c:/vcpkg/ -cmake-options "-DWANT_USE_STREFLOP=${{ matrix.streflop }}"
 
     - name: Git Hash
       run: echo "VERSION=$(git rev-parse --short HEAD)" >> $env:GITHUB_ENV
@@ -85,12 +90,12 @@ jobs:
         $7zPath = $(Get-Command 7z).Source
         cp $7zPath .
         Remove-Item glest-dev.ini
-        Compress-Archive -Path *.exe,*.ini -DestinationPath megaglest-x64-windows.zip
+        Compress-Archive -Path *.exe,*.ini -DestinationPath megaglest-x64-windows${{ matrix.streflop_suffix }}.zip
         cd ../..
 
     - name: Create MegaGlest Snapshot
       uses: actions/upload-artifact@v7
       with:
-        name: megaglest-x64-windows-archive
+        name: megaglest-x64-windows-archive${{ matrix.streflop_suffix }}
         retention-days: 1
         path: mk/windoze/*.zip


### PR DESCRIPTION
This most likely won't get merged, and doesn't need to be.

I wanted an artifact build without streflop to test #369

Extends the build-win64 matrix with streflop: [ON, OFF] so that a no-streflop build is produced alongside the default build. Each variant uploads its own artifact:
  megaglest-x64-windows-archive
  megaglest-x64-windows-archive-no-streflop