### PR TITLE
fix: Prevent BadWindow/heap-corruption crash when toggling fullscreen (#326)

### DIFF
--- a/source/shared_lib/sources/platform/sdl/gl_wrap.cpp
+++ b/source/shared_lib/sources/platform/sdl/gl_wrap.cpp
@@ -141,6 +141,12 @@ void PlatformContextGl::init(int colorBits, int depthBits, int stencilBits, bool
             }
             windowTitleText = SDL_GetWindowTitle(window);
 
+            // Detach the GL context from the window before destroying it so
+            // that SDL (and the underlying X11/EGL/WGL backend) does not try
+            // to use the window handle after it becomes invalid.
+            if (glcontext != NULL) {
+                SDL_GL_MakeCurrent(window, NULL);
+            }
             SDL_DestroyWindow(window);
             window = NULL;
         }

--- a/source/shared_lib/sources/platform/sdl/window_gl.cpp
+++ b/source/shared_lib/sources/platform/sdl/window_gl.cpp
@@ -95,15 +95,14 @@ void WindowGl::eventToggleFullScreen(bool isFullscreen) {
     Window::eventToggleFullScreen(isFullscreen);
 
     if (GlobalStaticFlags::getIsNonGraphicalModeEnabled() == false) {
-        // SDL_Surface *cur_surface = SDL_GetVideoSurface();
-        if (getScreenWindow() != NULL) {
-            if (getIsFullScreen()) {
-                SDL_SetWindowFullscreen(getScreenWindow(), SDL_WINDOW_FULLSCREEN_DESKTOP);
-            } else {
-                SDL_SetWindowFullscreen(getScreenWindow(), 0);
-            }
-        }
-
+        // Do NOT call SDL_SetWindowFullscreen here.  ChangeVideoMode (via
+        // initGl) destroys and recreates the window with the correct fullscreen
+        // flags set through shouldBeFullscreen.  Calling SDL_SetWindowFullscreen
+        // on the old window first queues X11 events (ConfigureNotify,
+        // PropertyNotify) that reference the old window handle.  When the old
+        // window is then destroyed before those events are processed, X11 raises
+        // a BadWindow error on XTranslateCoordinates which can corrupt the heap.
+        // See: https://github.com/MegaGlest/megaglest-source/issues/326
         if (isFullscreen) {
             changeVideoModeFullScreen(isFullscreen);
             ChangeVideoMode(true, getScreenWidth(), getScreenHeight(), true, context.getColorBits(), context.getDepthBits(), context.getStencilBits(),


### PR DESCRIPTION
## Summary

- Removes redundant `SDL_SetWindowFullscreen` call from `WindowGl::eventToggleFullScreen` that was queuing X11 events on a window about to be destroyed
- Adds `SDL_GL_MakeCurrent(window, NULL)` before `SDL_DestroyWindow` in `PlatformContextGl::init` to cleanly detach the GL context first

## Root cause

`eventToggleFullScreen` was calling `SDL_SetWindowFullscreen` on the existing window, then immediately calling `ChangeVideoMode` which destroys and recreates the window. The `SDL_SetWindowFullscreen` call queues X11 state-change events (`ConfigureNotify`, `PropertyNotify`) that reference the old window handle. When `SDL_DestroyWindow` is called before those events are processed, X11 raises `BadWindow` on `XTranslateCoordinates`, which corrupts the heap.

The `SDL_SetWindowFullscreen` call was entirely redundant: `ChangeVideoMode → initGl → PlatformContextGl::init` already destroys the old window and creates a new one with the correct fullscreen flags via `shouldBeFullscreen`.

The crash appears more frequently with `sdl2-compat` (SDL2 API over SDL3) which may have less lenient X error handling than native SDL2.

## Test plan
- [ ] Toggle fullscreen repeatedly with Alt+Enter during gameplay — no crash
- [ ] Verify fullscreen/windowed state toggles correctly

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)