### PR TITLE
fix: allow being-built buildings in control groups with built buildin…

### DIFF
--- a/source/glest_game/gui/selection.cpp
+++ b/source/glest_game/gui/selection.cpp
@@ -84,7 +84,7 @@ bool Selection::select(Unit *unit, bool addToSelection) {
 
         // check if multitypesel
         if (selectedUnits.size() > 0) {
-            bool isUnifromSelectOK = (selectedUnits.front()->getType() == unit->getType() && unit->isOperative() == selectedUnits.front()->isOperative());
+            bool isUnifromSelectOK = (selectedUnits.front()->getType() == unit->getType() && unit->isAlive() && selectedUnits.front()->isAlive());
             if (selectedUnits.front()->getType()->getUniformSelect() == true && !isUnifromSelectOK) {
                 if (addToSelection)
                     return false;
@@ -151,7 +151,7 @@ void Selection::select(const UnitContainer &units, bool addToSelection) {
 void Selection::selectType(Unit *unit) {
     UnitContainer units;
     for (int i = 0; i < (int)selectedUnits.size(); i++) {
-        if (selectedUnits[i]->getType() == unit->getType() && unit->isOperative() == selectedUnits[i]->isOperative()) {
+        if (selectedUnits[i]->getType() == unit->getType() && selectedUnits[i]->isAlive()) {
             units.push_back(selectedUnits[i]);
         }
     }
@@ -292,8 +292,8 @@ bool Selection::addUnitToGroup(int groupIndex, Unit *unit) {
     if ((int)groups[groupIndex].size() > 0) {
         Unit *unitInGroup = groups[groupIndex][0];
         if (unit->getType()->getUniformSelect() || unitInGroup->getType()->getUniformSelect()) {
-            if (unit->isOperative() != unitInGroup->isOperative()) {
-                // dont add units that are not in same operative state
+            if (!unit->isAlive() || !unitInGroup->isAlive()) {
+                // dont add dead units to a group
                 return false;
             }
             if (unitInGroup->getType() != unit->getType()) {


### PR DESCRIPTION
…gs (#253)

The uniformSelect check was using isOperative() (= isAlive() && isBuilt()) to compare units being added to a selection or group.  This prevented buildings under construction from joining a control group with completed buildings of the same type, since being-built units are alive but not yet "operative".

Replace the isOperative() comparison with isAlive() checks.  Dead units are still excluded, but being-built units (alive, same type) can now be grouped freely with finished units in select(), selectType(), and addUnitToGroup().

Fixes: https://github.com/MegaGlest/megaglest-source/issues/253