### PR TITLE
fix: address three threading issues that could cause intermittent OOS

### DIFF
--- a/source/glest_game/game/commander.cpp
+++ b/source/glest_game/game/commander.cpp
@@ -543,22 +543,25 @@ void Commander::updateNetwork(Game *game) {
                                              perfTimer.getMillis());
 
                 if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled) perfTimer.start();
-                // give pending commands
+                // Atomically take all pending commands, then process them from
+                // the local snapshot so no concurrent writer can interfere.
+                GameNetworkInterface::Commands pending;
+                gameNetworkInterface->takePendingCommands(pending);
                 if (SystemFlags::VERBOSE_MODE_ENABLED)
-                    printf("START process: %d network commands in frame: %d\n", gameNetworkInterface->getPendingCommandCount(), this->world->getFrameCount());
-                for (int i = 0; i < gameNetworkInterface->getPendingCommandCount(); ++i) {
-                    giveNetworkCommand(gameNetworkInterface->getPendingCommand(i));
+                    printf("START process: %d network commands in frame: %d\n", (int)pending.size(), this->world->getFrameCount());
+                for (int i = 0; i < (int)pending.size(); ++i) {
+                    giveNetworkCommand(&pending[i]);
                 }
                 if (SystemFlags::VERBOSE_MODE_ENABLED)
-                    printf("END process: %d network commands in frame: %d\n", gameNetworkInterface->getPendingCommandCount(), this->world->getFrameCount());
+                    printf("END process: %d network commands in frame: %d\n", (int)pending.size(), this->world->getFrameCount());
                 if (SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && perfTimer.getMillis() > 0)
                     SystemFlags::OutputDebug(SystemFlags::debugPerformance,
                                              "In [%s::%s Line: %d] giveNetworkCommand took %lld msecs, "
                                              "PendingCommandCount = %d\n",
                                              extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, perfTimer.getMillis(),
-                                             gameNetworkInterface->getPendingCommandCount());
-                gameNetworkInterface->clearPendingCommands();
-                if (SystemFlags::VERBOSE_MODE_ENABLED) printf("Cleared network commands in frame: %d\n", this->world->getFrameCount());
+                                             (int)pending.size());
+                if (SystemFlags::VERBOSE_MODE_ENABLED)
+                    printf("Processed %d network commands in frame: %d\n", (int)pending.size(), this->world->getFrameCount());
             }
         }
     }

--- a/source/glest_game/network/client_interface.cpp
+++ b/source/glest_game/network/client_interface.cpp
@@ -198,6 +198,7 @@ ClientInterface::ClientInterface() : GameNetworkInterface() {
                                  __FUNCTION__, __LINE__, this);
 
     networkCommandListThreadAccessor = new Mutex(CODE_AT_LINE);
+    pendingCommandsMutex = networkCommandListThreadAccessor;
     networkCommandListThread = NULL;
     cachedPendingCommandsIndex = 0;
     cachedLastPendingFrameCount = 0;

--- a/source/glest_game/network/network_interface.cpp
+++ b/source/glest_game/network/network_interface.cpp
@@ -450,6 +450,7 @@ float NetworkInterface::getThreadedPingMS(std::string host) {
 
 GameNetworkInterface::GameNetworkInterface() {
     quit = false;
+    pendingCommandsMutex = NULL;
 }
 
 void GameNetworkInterface::requestCommand(const NetworkCommand *networkCommand, bool insertAtStart) {

--- a/source/glest_game/network/network_interface.h
+++ b/source/glest_game/network/network_interface.h
@@ -296,12 +296,16 @@ class NetworkInterface {
 // =====================================================
 
 class GameNetworkInterface : public NetworkInterface {
-  protected:
+  public:
     typedef vector<NetworkCommand> Commands;
 
+  protected:
     Commands requestedCommands; // commands requested by the user
     Commands pendingCommands;   // commands ready to be given
     bool quit;
+    // Subclasses that populate pendingCommands from a background thread must
+    // set this to their access mutex; NULL means single-threaded access only.
+    Mutex *pendingCommandsMutex;
 
   public:
     GameNetworkInterface();
@@ -327,9 +331,12 @@ class GameNetworkInterface : public NetworkInterface {
 
     // access functions
     void requestCommand(const NetworkCommand *networkCommand, bool insertAtStart = false);
-    int getPendingCommandCount() const { return (int)pendingCommands.size(); }
-    NetworkCommand *getPendingCommand(int i) { return &pendingCommands[i]; }
-    void clearPendingCommands() { pendingCommands.clear(); }
+    // Atomically move all pending commands into `out`, leaving the queue empty.
+    // Thread-safe: acquires pendingCommandsMutex if set.
+    void takePendingCommands(Commands &out) {
+        MutexSafeWrapper safeMutex(pendingCommandsMutex, CODE_AT_LINE);
+        out.swap(pendingCommands);
+    }
     bool getQuit() const { return quit; }
 };
 

--- a/source/glest_game/network/server_interface.cpp
+++ b/source/glest_game/network/server_interface.cpp
@@ -62,6 +62,7 @@ ServerInterface::ServerInterface(bool publishEnabled, ClientLagCallbackInterface
 
     this->clientLagCallbackInterface = clientLagCallbackInterface;
     this->clientsAutoPausedDueToLag = false;
+    this->inLagCheck = false;
 
     allowInGameConnections = false;
     gameLaunched = false;
@@ -756,15 +757,13 @@ int64 ServerInterface::getNextEventId() {
 
 std::pair<bool, bool> ServerInterface::clientLagCheck(ConnectionSlot *connectionSlot, bool skipNetworkBroadCast) {
     std::pair<bool, bool> clientLagExceededOrWarned = std::make_pair(false, false);
-    static bool alreadyInLagCheck = false;
 
-    if (alreadyInLagCheck == true ||
-        (connectionSlot != NULL && (connectionSlot->getSkipLagCheck() == true || connectionSlot->getConnectHasHandshaked() == false))) {
+    if (inLagCheck == true || (connectionSlot != NULL && (connectionSlot->getSkipLagCheck() == true || connectionSlot->getConnectHasHandshaked() == false))) {
         return clientLagExceededOrWarned;
     }
 
     try {
-        alreadyInLagCheck = true;
+        inLagCheck = true;
 
         if ((gameStartTime > 0 && difftime((long int)time(NULL), gameStartTime) >= LAG_CHECK_GRACE_PERIOD) &&
             (resumeGameStartTime == 0 || (resumeGameStartTime > 0 && difftime((long int)time(NULL), resumeGameStartTime) >= LAG_CHECK_GRACE_PERIOD))) {
@@ -906,7 +905,7 @@ std::pair<bool, bool> ServerInterface::clientLagCheck(ConnectionSlot *connection
             }
         }
     } catch (const exception &ex) {
-        alreadyInLagCheck = false;
+        inLagCheck = false;
 
         SystemFlags::OutputDebug(SystemFlags::debugError, "In [%s::%s Line: %d] Error [%s]\n", extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__,
                                  __LINE__, ex.what());
@@ -916,7 +915,7 @@ std::pair<bool, bool> ServerInterface::clientLagCheck(ConnectionSlot *connection
         throw megaglest_runtime_error(ex.what());
     }
 
-    alreadyInLagCheck = false;
+    inLagCheck = false;
     return clientLagExceededOrWarned;
 }
 
@@ -1762,32 +1761,38 @@ void ServerInterface::updateKeyframe(int frameCount) {
         networkMessageCommandList.setNetworkPlayerFactionCRC(index, this->getNetworkPlayerFactionCRC(index));
     }
 
-    while (requestedCommands.empty() == false) {
-        // First add the command to the broadcast list (for all clients)
-        if (networkMessageCommandList.addCommand(&requestedCommands.back())) {
-            // Add the command to the local server command list
-            pendingCommands.push_back(requestedCommands.back());
-            requestedCommands.pop_back();
-        } else {
-            break;
+    size_t overflowCount = 0;
+    {
+        MutexSafeWrapper safeMutex(serverSynchAccessor, CODE_AT_LINE);
+        while (requestedCommands.empty() == false) {
+            // First add the command to the broadcast list (for all clients)
+            if (networkMessageCommandList.addCommand(&requestedCommands.back())) {
+                // Add the command to the local server command list
+                pendingCommands.push_back(requestedCommands.back());
+                requestedCommands.pop_back();
+            } else {
+                break;
+            }
         }
+        // Capture overflow count while still holding the lock.
+        overflowCount = requestedCommands.size();
     }
 
     try {
         // Possible cause of out of synch since we have more commands that need
         // to be sent in this frame
-        if (requestedCommands.empty() == false) {
+        if (overflowCount > 0) {
             if (SystemFlags::getSystemSettingType(SystemFlags::debugNetwork).enabled)
                 SystemFlags::OutputDebug(SystemFlags::debugNetwork,
                                          "In [%s::%s Line: %d] WARNING / ERROR, "
-                                         "requestedCommands.size() = %d\n",
-                                         extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, requestedCommands.size());
+                                         "requestedCommands.size() = %zu\n",
+                                         extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, overflowCount);
             SystemFlags::OutputDebug(SystemFlags::debugError,
                                      "In [%s::%s Line: %d] WARNING / ERROR, "
-                                     "requestedCommands.size() = %d\n",
-                                     extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, requestedCommands.size());
+                                     "requestedCommands.size() = %zu\n",
+                                     extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__, overflowCount);
 
-            string sMsg = "may go out of synch: server requestedCommands.size() = " + intToStr(requestedCommands.size());
+            string sMsg = "may go out of synch: server requestedCommands.size() = " + intToStr(overflowCount);
             sendTextMessage(sMsg, -1, true, "");
         }
 

--- a/source/glest_game/network/server_interface.h
+++ b/source/glest_game/network/server_interface.h
@@ -115,6 +115,7 @@ class ServerInterface : public GameNetworkInterface,
     Chrono clientsAutoPausedDueToLagTimer;
     Chrono lastBroadcastCommandsTimer;
     ClientLagCallbackInterface *clientLagCallbackInterface;
+    bool inLagCheck;
 
   public:
     ServerInterface(bool publishEnabled, ClientLagCallbackInterface *clientLagCallbackInterface);


### PR DESCRIPTION
1. Replace piecemeal pendingCommands access with atomic takePendingCommands() snapshot, guarded by pendingCommandsMutex (shared with the client's networkCommandListThreadAccessor), eliminating a TOCTOU race between the network receive thread and the game-loop thread.

2. Replace static-local alreadyInLagCheck with a ServerInterface member variable inLagCheck, so the reentrancy guard is per-instance and is properly reset on construction.

3. Wrap the requestedCommands drain loop in updateKeyframe() with serverSynchAccessor, which already guards requestCommand() writes. Overflow count is captured inside the lock and the warning broadcast is sent after releasing it to avoid potential deadlock.