### PR TITLE
fix: skip the human option on non-human player slots

### DIFF
--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -675,7 +675,19 @@ MenuStateCustomGame::MenuStateCustomGame(Program *program, MainMenu *mainMenu, b
             listBoxTeams[i].setSelectedItemIndex(i);
             lastSelectedTeamIndex[i] = listBoxTeams[i].getSelectedItemIndex();
 
-            listBoxControls[i].setItems(controlItems);
+            //by default the main player is at position 0, for any other position make sure the "human" option is not appliccable (skip)
+            if (i == 0) {
+                listBoxControls[i].setItems(controlItems);
+            } else {
+                vector<string> controlItemsNoHuman;
+                for (const string& item : controlItems) {
+                    if (item != lang.getString("Human")) {
+                        controlItemsNoHuman.push_back(item);
+                    }
+                }
+                    listBoxControls[i].setItems(controlItemsNoHuman);
+            }
+
             listBoxRMultiplier[i].setItems(rMultiplier);
             listBoxRMultiplier[i].setSelectedItem("1.0");
             labelNetStatus[i].setText("");
@@ -892,7 +904,17 @@ void MenuStateCustomGame::reloadUI() {
     for (int i = 0; i < GameConstants::maxPlayers; ++i) {
         labelPlayers[i].setText(intToStr(i + 1));
 
-        listBoxControls[i].setItems(controlItems);
+            if (i == 0) {
+                  listBoxControls[i].setItems(controlItems);
+            } else {
+                vector<string> controlItemsNoHuman;
+                for (const string& item : controlItems) {
+                    if (item != lang.getString("Human")) {
+                        controlItemsNoHuman.push_back(item);
+                    }
+                }
+                listBoxControls[i].setItems(controlItemsNoHuman);
+            }
     }
 
     labelFallbackCpuMultiplier.setText(lang.getString("FallbackCpuMultiplier"));

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -675,19 +675,7 @@ MenuStateCustomGame::MenuStateCustomGame(Program *program, MainMenu *mainMenu, b
             listBoxTeams[i].setSelectedItemIndex(i);
             lastSelectedTeamIndex[i] = listBoxTeams[i].getSelectedItemIndex();
 
-            //by default the main player is at position 0, for any other position make sure the "human" option is not appliccable (skip)
-            if (i == 0) {
-                listBoxControls[i].setItems(controlItems);
-            } else {
-                vector<string> controlItemsNoHuman;
-                for (const string& item : controlItems) {
-                    if (item != lang.getString("Human")) {
-                        controlItemsNoHuman.push_back(item);
-                    }
-                }
-                    listBoxControls[i].setItems(controlItemsNoHuman);
-            }
-
+            fixControlItemsForSlot(i, controlItems);
             listBoxRMultiplier[i].setItems(rMultiplier);
             listBoxRMultiplier[i].setSelectedItem("1.0");
             labelNetStatus[i].setText("");
@@ -903,18 +891,7 @@ void MenuStateCustomGame::reloadUI() {
 
     for (int i = 0; i < GameConstants::maxPlayers; ++i) {
         labelPlayers[i].setText(intToStr(i + 1));
-
-            if (i == 0) {
-                  listBoxControls[i].setItems(controlItems);
-            } else {
-                vector<string> controlItemsNoHuman;
-                for (const string& item : controlItems) {
-                    if (item != lang.getString("Human")) {
-                        controlItemsNoHuman.push_back(item);
-                    }
-                }
-                listBoxControls[i].setItems(controlItemsNoHuman);
-            }
+        fixControlItemsForSlot(i, controlItems);
     }
 
     labelFallbackCpuMultiplier.setText(lang.getString("FallbackCpuMultiplier"));
@@ -1787,6 +1764,17 @@ void MenuStateCustomGame::mouseClick(int x, int y, MouseButton mouseButton) {
 
     if (SystemFlags::getSystemSettingType(SystemFlags::debugSystem).enabled)
         SystemFlags::OutputDebug(SystemFlags::debugSystem, "In [%s::%s Line %d]\n", extractFileFromDirectoryPath(__FILE__).c_str(), __FUNCTION__, __LINE__);
+}
+
+//skip human option for non-human player slots
+void MenuStateCustomGame::fixControlItemsForSlot(int slotIndex, const vector<string> &controlItems) {
+    if (slotIndex == 0) {
+        listBoxControls[slotIndex].setItems(controlItems);
+    } else {
+        vector<string> controlItemsNoHuman = controlItems;
+        controlItemsNoHuman.erase(controlItemsNoHuman.begin() + ctHuman);
+        listBoxControls[slotIndex].setItems(controlItemsNoHuman);
+    }
 }
 
 void MenuStateCustomGame::updateAllResourceMultiplier() {

--- a/source/glest_game/menu/menu_state_custom_game.h
+++ b/source/glest_game/menu/menu_state_custom_game.h
@@ -318,6 +318,7 @@ class MenuStateCustomGame : public MenuState, public SimpleTaskCallbackInterface
     void reloadFactions(bool keepExistingSelectedItem, string scenario);
     void setupTilesetList(string scenario);
     void setSlotHuman(int i);
+    void fixControlItemsForSlot(int slotIndex, const vector<string> &controlItems);
 
     void initFactionPreview(const GameSettings *gameSettings);
 


### PR DESCRIPTION
I made a small optimization but I'd like to see it being considered as an issue even if the pull request doesn't get approved cause it was getting on my nerves. So, when you try to create a custom scenario, evidently you cannot choose the "human" option on any other slot other than yours, yet when you attempt to, instead of the game just omitting entirely the option to put "human" on the slot for some reason it switches the position of your (the main player's) slot with the one you're editing. I don't know if it is a deliberate choice but in any case i found this switcheroo annoying when trying to host a game and I guess other players may have found it annoying too. I made this small change to fix it.