### PR TITLE
fixed the map editor crash after pressing cancel

### DIFF
--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -471,7 +471,13 @@ void MainWindow::onClose(wxCloseEvent &event) {
 		if( wxMessageDialog(NULL, ToUnicode("Do you want to save the current map?"),
 			ToUnicode("Question"), wxYES_NO | wxYES_DEFAULT).ShowModal() == wxID_YES) {
 			wxCommandEvent ev;
-			MainWindow::onMenuFileSave(ev);
+            MainWindow::onMenuFileSave(ev);
+            if (program->getMap()->getHasChanged() == true) {
+                if (event.CanVeto()) {
+                    event.Veto();
+                }
+                return;
+            }
 		}
 	}
 	delete program;


### PR DESCRIPTION
Fixes #353

In onClose(), after the user clicks Yes to save, if they then click cancel  code proceeds to delete the program object.

A simple fix is to just deny the map editor window the ability to close whatever the choice may be after "yes" (cancel or save). Seems to work fine without any crashes after the fix.