### PR TITLE
mk/macos/build-mg.sh: resolve @rpath/ dylib references in bundle walk

### DIFF
--- a/mk/macos/build-mg.sh
+++ b/mk/macos/build-mg.sh
@@ -135,20 +135,43 @@ if [ "$BUILD_BUNDLE" -eq "1" ]; then
 	if [ -e "megaglest" ] && [ "$(./megaglest --version >/dev/null; echo "$?")" -eq "0" ]; then
 		if [ -d "lib" ]; then rm -rf "lib"; fi
 		mkdir -p "lib"
+		# Recent Homebrew bottles use @rpath/<name> references between dylibs
+		# instead of absolute paths. otool -L on an unresolved @rpath/foo
+		# fails with "can't open file", so we map @rpath/<name> to the actual
+		# file on disk by looking under the standard Homebrew lib prefixes.
+		resolve_rpath() {
+			case "$1" in
+				@rpath/*)
+					local name="${1#@rpath/}"
+					for prefix in /opt/homebrew/lib /usr/local/lib; do
+						if [ -f "$prefix/$name" ]; then
+							echo "$prefix/$name"
+							return
+						fi
+					done
+					echo "$1"
+					;;
+				*)
+					echo "$1"
+					;;
+			esac
+		}
 		list_of_libs="$(otool -L megaglest | grep -v '/System/Library/Frameworks/' | grep -v '/usr/lib/' | awk '{print $1}' | sed '/:$/d')"
 		for (( i=1; i<=50; i++ )); do
 		    for dyn_lib in $list_of_libs; do
-			if [ "$(echo "$list_of_checked_libs" | grep "$dyn_lib")" = "" ]; then
-			    list_of_libs2="$(otool -L "$dyn_lib" | grep -v '/System/Library/Frameworks/' | grep -v '/usr/lib/' | awk '{print $1}')"
+			resolved_lib="$(resolve_rpath "$dyn_lib")"
+			if [ "$(echo "$list_of_checked_libs" | grep "$resolved_lib")" = "" ]; then
+			    list_of_libs2="$(otool -L "$resolved_lib" | grep -v '/System/Library/Frameworks/' | grep -v '/usr/lib/' | awk '{print $1}')"
 			    list_of_libs="$(echo "$list_of_libs
 $list_of_libs2" | sed '/:$/d' | sed '/^$/d' | sort -u )"
-			    list_of_checked_libs="$list_of_checked_libs $dyn_lib"
+			    list_of_checked_libs="$list_of_checked_libs $resolved_lib"
 			fi
 		    done
 		done
 		for dyn_lib in $list_of_libs; do
-		    case "$dyn_lib" in
-			/*) cp "$dyn_lib" "lib/";;
+		    resolved_lib="$(resolve_rpath "$dyn_lib")"
+		    case "$resolved_lib" in
+			/*) cp "$resolved_lib" "lib/";;
 		    esac
 		done
 	else


### PR DESCRIPTION
The dylib-collecting loop in BUILD_BUNDLE mode walks otool -L output recursively, but newer Homebrew bottles record inter-dylib references as @rpath/<name> instead of absolute paths. otool -L on an unresolved @rpath/foo fails with "can't open file", aborting the build with:

    error: ...otool-classic: can't open file:
        @rpath/libbrotlicommon.1.dylib (No such file or directory)

and the subsequent cp fails because @rpath/... isn't a real path either ("cp: lib/libngtcp2.16.dylib: Permission denied").

Resolve @rpath/<name> by probing the standard Homebrew lib prefixes (/opt/homebrew/lib on Apple Silicon, /usr/local/lib on Intel) and use the resolved absolute path for both the recursive otool walk and the final cp into lib/. Non-@rpath paths pass through unchanged, so existing behavior is preserved for any dylib that still hardcodes its full path.

This unblocks the develop-only "Prepare Snapshot" step that has been failing on macOS runners since ~May 19 (commit 2adee8c, the brew cache change). The step is gated on github.ref == refs/heads/develop so it never runs in PR builds — the failure only manifests after merge.