### PR TITLE
mesh: support per-pixel transparency on team-colored meshes

### DIFF
--- a/source/glest_game/graphics/renderer.cpp
+++ b/source/glest_game/graphics/renderer.cpp
@@ -92,10 +92,26 @@ void MeshCallbackTeamColor::execute(const Mesh *mesh) {
         glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE1_RGB, GL_PREVIOUS);
         glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB, GL_SRC_COLOR);
 
-        // set alpha to 1
-        glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE);
-        glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PRIMARY_COLOR);
-        glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
+        if (mesh->getAlphaIsTransparency()) {
+            // Texture's per-pixel alpha multiplies the mesh's uniform opacity,
+            // yielding sheer-fabric / partial-transparency effects on top of
+            // team-color blending. Stage 0 left output alpha = texture0.alpha
+            // (its "set alpha = 1" comment is misleading — REPLACE writes the
+            // texture's alpha through), so we MODULATE with primary_color.alpha
+            // here.
+            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_MODULATE);
+            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PRIMARY_COLOR);
+            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
+            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE1_ALPHA, GL_PREVIOUS);
+            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
+        } else {
+            // Default behavior: discard texture alpha, use mesh opacity only.
+            // Keeps existing assets unaffected — those rely on alpha=0 marking
+            // team-color regions without making them transparent.
+            glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_REPLACE);
+            glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE0_ALPHA, GL_PRIMARY_COLOR);
+            glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
+        }
 
         glActiveTexture(GL_TEXTURE0);
     } else {

--- a/source/shared_lib/include/graphics/model.h
+++ b/source/shared_lib/include/graphics/model.h
@@ -75,6 +75,7 @@ class Mesh {
     bool customColor;
     bool noSelect;
     bool glow;
+    bool alphaIsTransparency;
 
     uint32 textureFlags;
 
@@ -137,6 +138,7 @@ class Mesh {
     bool getCustomTexture() const { return customColor; }
     bool getNoSelect() const { return noSelect; }
     bool getGlow() const { return glow; }
+    bool getAlphaIsTransparency() const { return alphaIsTransparency; }
     string getName() const { return name; }
 
     uint32 getTextureFlags() const { return textureFlags; }

--- a/source/shared_lib/include/graphics/model_header.h
+++ b/source/shared_lib/include/graphics/model_header.h
@@ -39,7 +39,19 @@ struct ModelHeader {
 
 enum ModelType { mtMorphMesh };
 
-enum MeshPropertyFlag { mpfCustomColor = 1, mpfTwoSided = 2, mpfNoSelect = 4, mpfGlow = 8 };
+enum MeshPropertyFlag {
+    mpfCustomColor = 1,
+    mpfTwoSided = 2,
+    mpfNoSelect = 4,
+    mpfGlow = 8,
+    // When set together with mpfCustomColor, the renderer modulates the final
+    // alpha by the texture's per-pixel alpha instead of replacing it with the
+    // mesh's uniform opacity. This makes the texture's alpha channel control
+    // BOTH team-color blending (existing behavior) AND per-pixel transparency
+    // (new). Useful for sheer-fabric effects on a team-colored mesh.
+    // Existing assets are unaffected because the flag is opt-in.
+    mpfAlphaIsTransparency = 16
+};
 
 enum MeshTexture {
     mtDiffuse,

--- a/source/shared_lib/sources/graphics/model.cpp
+++ b/source/shared_lib/sources/graphics/model.cpp
@@ -228,6 +228,7 @@ Mesh::Mesh() {
     customColor = false;
     noSelect = false;
     glow = false;
+    alphaIsTransparency = false;
 
     textureFlags = 0;
 
@@ -459,6 +460,7 @@ void Mesh::loadV2(int meshIndex, const string &dir, FILE *f, TextureManager *tex
     customColor = false;
     noSelect = false;
     glow = false;
+    alphaIsTransparency = false;
 
     if (SystemFlags::VERBOSE_MODE_ENABLED)
         printf("Load v2, this = %p Found meshHeader.hasTexture = %d, texName [%s] "
@@ -827,6 +829,7 @@ void Mesh::load(int meshIndex, const string &dir, FILE *f, TextureManager *textu
     twoSided = (meshHeader.properties & mpfTwoSided) != 0;
     noSelect = (meshHeader.properties & mpfNoSelect) != 0;
     glow = (meshHeader.properties & mpfGlow) != 0;
+    alphaIsTransparency = (meshHeader.properties & mpfAlphaIsTransparency) != 0;
 
     // material
     diffuseColor = Vec3f(meshHeader.diffuseColor);
@@ -962,6 +965,9 @@ void Mesh::save(int meshIndex, const string &dir, FILE *f, TextureManager *textu
     }
     if (glow) {
         meshHeader.properties |= mpfGlow;
+    }
+    if (alphaIsTransparency) {
+        meshHeader.properties |= mpfAlphaIsTransparency;
     }
 
     meshHeader.textures = textureFlags;
@@ -1560,6 +1566,7 @@ void Mesh::copyInto(Mesh *dest, bool ignoreInterpolationData, bool destinationOw
     dest->customColor = this->customColor;
     dest->noSelect = this->noSelect;
     dest->glow = this->glow;
+    dest->alphaIsTransparency = this->alphaIsTransparency;
 
     dest->textureFlags = this->textureFlags;
 


### PR DESCRIPTION
Add a new MeshPropertyFlag, mpfAlphaIsTransparency (bit 4 = value 16). When set together with mpfCustomColor, the renderer modulates the final alpha by the texture's per-pixel alpha instead of replacing it with the mesh's uniform opacity. This makes the texture's alpha channel control BOTH team-color blending (existing behavior) AND per-pixel transparency (new), so you can author sheer-fabric effects on a still-team-colored mesh.

Without this flag, behavior is unchanged: alpha is overwritten by glColor.a (the mesh's opacity), so existing assets with alpha < 255 team-color zones don't accidentally become see-through.

Changes:
  - model_header.h: add mpfAlphaIsTransparency = 16 to the MeshPropertyFlag enum.
  - model.h: add bool alphaIsTransparency + getAlphaIsTransparency().
  - model.cpp: parse, write, init, copyInto the new field.
  - renderer.cpp (MeshCallbackTeamColor::execute): branch on the flag when configuring the second texture-env stage's alpha combiner — REPLACE (current) vs MODULATE (new, multiplying texture alpha with primary_color.alpha).

Blender plugin support for setting/clearing this flag will be a follow-up change.