### PR TITLE
g3d_viewer: don't iconize window in auto-screenshot mode

### DIFF
--- a/source/g3d_viewer/main.cpp
+++ b/source/g3d_viewer/main.cpp
@@ -2564,11 +2564,10 @@ bool App::OnInit() {
 
     mainWindow = new MainWindow(unitToLoad, modelPath, particlePath, projectileParticlePath, splashParticlePath, newAnimValue, newParticleLoopValue,
                                 newZoomValue, newXRotValue, newYRotValue, appPath);
-    if (autoScreenShotAndExit == true) {
-#if !defined(WIN32)
-        mainWindow->Iconize(true);
-#endif
-    }
+    // Note: previously we called mainWindow->Iconize(true) before Show() in
+    // auto-screenshot mode on non-WIN32 to keep the window hidden, but on
+    // Linux/Mesa this prevents the GL canvas from rendering and the captured
+    // screenshot is blank. Show normally; the window flashes briefly then exits.
     mainWindow->Show();
     mainWindow->init();
     mainWindow->Update();


### PR DESCRIPTION
App::OnInit previously called mainWindow->Iconize(true) before Show() in auto-screenshot mode on non-WIN32 platforms to keep the window hidden. On Linux/Mesa this prevents the GL canvas from rendering, so the captured framebuffer is blank — auto-screenshot mode produced empty PNGs (just transparency or background fill).

Drop the Iconize call. The window flashes briefly then closes after the screenshot saves, which is acceptable for CLI / automation use and trades one second of visible window for screenshots that actually contain the model.