### PR TITLE
map editor: require wxWidgets ≥ 3.0, remove pre-wx-3 dead code

### DIFF
--- a/source/glest_map_editor/CMakeLists.txt
+++ b/source/glest_map_editor/CMakeLists.txt
@@ -38,7 +38,7 @@ IF(BUILD_MEGAGLEST_MAP_EDITOR)
 
 	# It was noticed that when using MinGW gcc it is essential that 'core' is mentioned before 'base'.
 	# Optimal order most likely is gl > core > base, in some cases it may do difference.
-	FIND_PACKAGE(wxWidgets REQUIRED COMPONENTS gl core base)
+	FIND_PACKAGE(wxWidgets 3.0 REQUIRED COMPONENTS gl core base)
 
 	IF(UNIX OR WIN32)
 		# wxWidgets include (this will do all the magic to configure everything)

--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -1513,8 +1513,7 @@ END_EVENT_TABLE()
 // class GlCanvas
 // =====================================================
 
-GlCanvas::GlCanvas(MainWindow *mainWindow, wxWindow *parent, int *args)
-    : wxGLCanvas(parent, -1, args, wxDefaultPosition, wxDefaultSize, 0, wxT("GLCanvas")) {
+GlCanvas::GlCanvas(MainWindow *mainWindow, wxWindow *parent, int *args) : wxGLCanvas(parent, -1, args, wxDefaultPosition, wxDefaultSize, 0, wxT("GLCanvas")) {
     this->context = new wxGLContext(this);
     this->mainWindow = mainWindow;
 }
@@ -1657,8 +1656,7 @@ bool App::OnInit() {
     if (argc == 2) {
         if (argv[1][0] == '-') { // any flag gives help and exits program.
             std::cout << std::endl
-                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << wxString(wxVERSION_STRING).utf8_string() << "]"
-                      << std::endl
+                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << wxString(wxVERSION_STRING).utf8_string() << "]" << std::endl
                       << std::endl;
             // std::cout << "\nglest_map_editor [MGM FILE]" << std::endl << std::endl;
             std::cout << "Creates or edits megaglest/glest maps. [.mgm/.gbm]" << std::endl << std::endl;

--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -454,15 +454,6 @@ void MainWindow::init(string fname) {
     // setExtension();
 
     initGlCanvas();
-#if wxCHECK_VERSION(2, 9, 3)
-    // glCanvas->setCurrentGLContext();
-    // printf("setcurrent #1\n");
-#elif wxCHECK_VERSION(2, 9, 1)
-
-#else
-    if (glCanvas) glCanvas->SetCurrent();
-    // printf("setcurrent #2\n");
-#endif
 
     if (startupSettingsInited == false) {
         startupSettingsInited = true;
@@ -699,12 +690,7 @@ void MainWindow::onMenuFileLoad(wxCommandEvent &event) {
         fileDialog->SetWildcard(wxT("Glest&Mega Map (*.gbm *.mgm)|*.gbm;*.mgm|Glest Map "
                                     "(*.gbm)|*.gbm|Mega Map (*.mgm)|*.mgm"));
         if (fileDialog->ShowModal() == wxID_OK) {
-#if wxCHECK_VERSION(2, 9, 1)
             currentFile = fileDialog->GetPath().ToStdString();
-#else
-            const wxWX2MBbuf tmp_buf = wxConvCurrent->cWX2MB(fileDialog->GetPath());
-            currentFile = tmp_buf;
-#endif
 
             // printf("#1 file load [%s]\n",currentFile.c_str());
 
@@ -744,11 +730,7 @@ void MainWindow::onMenuFileSaveAs(wxCommandEvent &event) {
         return;
     }
 
-#if wxCHECK_VERSION(2, 9, 1)
     wxFileDialog fd(this, wxT("Select file"), wxT(""), wxT(""), wxT("*.mgm|*.gbm"), wxFD_SAVE);
-#else
-    wxFileDialog fd(this, wxT("Select file"), wxT(""), wxT(""), wxT("*.mgm|*.gbm"), wxSAVE);
-#endif
 
     if (fileDialog->GetPath() != ToUnicode("")) {
         fd.SetPath(fileDialog->GetPath());
@@ -764,12 +746,7 @@ void MainWindow::onMenuFileSaveAs(wxCommandEvent &event) {
 
     fd.SetWildcard(wxT("MegaGlest Map (*.mgm)|*.mgm|Glest Map (*.gbm)|*.gbm"));
     if (fd.ShowModal() == wxID_OK) {
-#if wxCHECK_VERSION(2, 9, 1)
         currentFile = fd.GetPath().ToStdString();
-#else
-        const wxWX2MBbuf tmp_buf = wxConvCurrent->cWX2MB(fd.GetPath());
-        currentFile = tmp_buf;
-#endif
 
         fileDialog->SetPath(fd.GetPath());
         setExtension();
@@ -1037,12 +1014,7 @@ void MainWindow::onMenuEditImportHeights(wxCommandEvent &event) {
         wxString savedDir = fileDialog->GetDirectory();
         fileDialog->SetDirectory(heightMapDirectory);
         if (fileDialog->ShowModal() == wxID_OK) {
-#if wxCHECK_VERSION(2, 9, 1)
             currentFile = fileDialog->GetPath().ToStdString();
-#else
-            const wxWX2MBbuf tmp_buf = wxConvCurrent->cWX2MB(fileDialog->GetPath());
-            currentFile = tmp_buf;
-#endif
 
             wxImage *img = new wxImage(currentFile);
             if (img != NULL) {
@@ -1074,7 +1046,6 @@ void MainWindow::onMenuEditExportHeights(wxCommandEvent &event) {
     if (program == NULL) {
         return;
     }
-#if wxCHECK_VERSION(2, 9, 1)
     wxFileDialog fd(this, wxT("Select file"), wxT(""), wxT(""),
                     wxT("All "
                         "Images|*.bmp;*.png;*.jpg;*.jpeg;*.gif;.*.tga;*.tiff;*."
@@ -1082,23 +1053,9 @@ void MainWindow::onMenuEditExportHeights(wxCommandEvent &event) {
                         "*.jpeg)|*.jpg;*.jpeg|BMP-Image (*.bmp)|*.bmp|GIF-Image "
                         "(*.gif)|*.gif|TIFF-Image (*.tif, *.tiff)|*.tiff;*.tif"),
                     wxFD_SAVE);
-#else
-    wxFileDialog fd(this, wxT("Select file"), wxT(""), wxT(""),
-                    wxT("All "
-                        "Images|*.bmp;*.png;*.jpg;*.jpeg;*.gif;.*.tga;*.tiff;*."
-                        "tif|PNG-Image (*.png)|*.png|JPEG-Image (*.jpg, "
-                        "*.jpeg)|*.jpg;*.jpeg|BMP-Image (*.bmp)|*.bmp|GIF-Image "
-                        "(*.gif)|*.gif|TIFF-Image (*.tif, *.tiff)|*.tiff;*.tif"),
-                    wxSAVE);
-#endif
     fd.SetDirectory(heightMapDirectory);
     if (fd.ShowModal() == wxID_OK) {
-#if wxCHECK_VERSION(2, 9, 1)
         currentFile = fd.GetPath().ToStdString();
-#else
-        const wxWX2MBbuf tmp_buf = wxConvCurrent->cWX2MB(fd.GetPath());
-        currentFile = tmp_buf;
-#endif
         int map_w = program->getMap()->getW();
         int map_h = program->getMap()->getH();
         wxImage img(map_w, map_h);
@@ -1557,14 +1514,8 @@ END_EVENT_TABLE()
 // =====================================================
 
 GlCanvas::GlCanvas(MainWindow *mainWindow, wxWindow *parent, int *args)
-#if wxCHECK_VERSION(2, 9, 1)
     : wxGLCanvas(parent, -1, args, wxDefaultPosition, wxDefaultSize, 0, wxT("GLCanvas")) {
     this->context = new wxGLContext(this);
-#else
-    : wxGLCanvas(parent, -1, wxDefaultPosition, wxDefaultSize, 0, wxT("GLCanvas"), args) {
-    this->context = NULL;
-#endif
-
     this->mainWindow = mainWindow;
 }
 
@@ -1574,11 +1525,9 @@ GlCanvas::~GlCanvas() {
 }
 
 void GlCanvas::setCurrentGLContext() {
-#if wxCHECK_VERSION(2, 9, 1)
     if (this->context == NULL) {
         this->context = new wxGLContext(this);
     }
-#endif
 
     if (this->context) {
         this->SetCurrent(*this->context);
@@ -1708,7 +1657,7 @@ bool App::OnInit() {
     if (argc == 2) {
         if (argv[1][0] == '-') { // any flag gives help and exits program.
             std::cout << std::endl
-                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << (const char *)wxConvCurrent->cWX2MB(wxVERSION_STRING) << "]"
+                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << wxString(wxVERSION_STRING).utf8_string() << "]"
                       << std::endl
                       << std::endl;
             // std::cout << "\nglest_map_editor [MGM FILE]" << std::endl << std::endl;
@@ -1722,13 +1671,7 @@ bool App::OnInit() {
             std::cout << std::endl;
             exit(0);
         }
-// #if defined(__MINGW32__)
-#if wxCHECK_VERSION(2, 9, 1)
         fileparam = argv[1].ToStdString();
-#else
-        const wxWX2MBbuf tmp_buf = wxConvCurrent->cWX2MB(argv[1]);
-        fileparam = tmp_buf;
-#endif
 
 #ifdef WIN32
         auto_ptr<wchar_t> wstr(Ansi2WideString(fileparam.c_str()));
@@ -1750,11 +1693,7 @@ bool App::OnInit() {
     // exe_path += path_separator;
 
     string appPath;
-#if wxCHECK_VERSION(2, 9, 1)
     appPath = exe_path.ToStdString();
-#else
-    appPath = wxFNCONV(exe_path);
-#endif
 
     // #else
     //		const wxWX2MBbuf tmp_buf =

--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -1656,7 +1656,8 @@ bool App::OnInit() {
     if (argc == 2) {
         if (argv[1][0] == '-') { // any flag gives help and exits program.
             std::cout << std::endl
-                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << (const char *) wxString(wxVERSION_STRING).utf8_str() << "]" << std::endl
+                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << (const char *)wxString(wxVERSION_STRING).utf8_str() << "]"
+                      << std::endl
                       << std::endl;
             // std::cout << "\nglest_map_editor [MGM FILE]" << std::endl << std::endl;
             std::cout << "Creates or edits megaglest/glest maps. [.mgm/.gbm]" << std::endl << std::endl;

--- a/source/glest_map_editor/main.cpp
+++ b/source/glest_map_editor/main.cpp
@@ -1656,7 +1656,7 @@ bool App::OnInit() {
     if (argc == 2) {
         if (argv[1][0] == '-') { // any flag gives help and exits program.
             std::cout << std::endl
-                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << wxString(wxVERSION_STRING).utf8_string() << "]" << std::endl
+                      << "MegaGlest map editor " << mapeditorVersionString << " [Using " << (const char *) wxString(wxVERSION_STRING).utf8_str() << "]" << std::endl
                       << std::endl;
             // std::cout << "\nglest_map_editor [MGM FILE]" << std::endl << std::endl;
             std::cout << "Creates or edits megaglest/glest maps. [.mgm/.gbm]" << std::endl << std::endl;


### PR DESCRIPTION
> Drafted by Claude (Anthropic LLM) at @andy5995's direction.

wx 3.x has WXWIN_COMPATIBILITY_2_8 off by default, but the wxCHECK_VERSION(2,9,1) and (2,9,3) blocks in main.cpp kept the pre-wx-3 #else paths as dead code on any modern host — papering over the migration instead of completing it. Removed all 11 such blocks, kept the wx-3 branch only. Modernized one remaining wxConvCurrent->cWX2MB call to wxString::utf8_string(). Pinned FIND_PACKAGE(wxWidgets 3.0 ...) so future builds can't silently regress to a 2.x host.